### PR TITLE
fix: go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/drogonsec/drogonsec
+module github.com/filipi86/drogonsec
 
 go 1.24.0
 


### PR DESCRIPTION
Fixes

```
go run github.com/filipi86/drogonsec/cmd/drogonsec@main . 
go: downloading github.com/filipi86/drogonsec v0.0.0-20260406122009-48700eb02b2b go: github.com/filipi86/drogonsec/cmd/drogonsec@main: version constraints conflict:
        github.com/filipi86/drogonsec@v0.0.0-20260406122009-48700eb02b2b: parsing go.mod:
        module declares its path as: github.com/drogonsec/drogonsec
                but was required as: github.com/filipi86/drogonsec
```