### PR TITLE
fix(multi): correct six bugs across cli, engine, reporter, ai and monitor

### DIFF
--- a/internal/ai/claude.go
+++ b/internal/ai/claude.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -341,7 +342,11 @@ func (c *Client) callCloud(prompt, system string, tokens int) (string, error) {
 		return "", fmt.Errorf("marshal error: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.cfg.Endpoint, bytes.NewReader(body))
+	// context.Background() allows the http.Client Timeout to remain the sole
+	// deadline — callers do not yet pass a context, but using
+	// NewRequestWithContext makes future propagation trivial without changing
+	// the call sites again.
+	req, err := http.NewRequestWithContext(context.Background(), "POST", c.cfg.Endpoint, bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("request creation error: %w", err)
 	}
@@ -394,7 +399,9 @@ func (c *Client) callOllama(prompt, system string, tokens int) (string, error) {
 		return "", fmt.Errorf("marshal error: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.cfg.Endpoint, bytes.NewReader(body))
+	// context.Background() mirrors the callCloud approach — the http.Client
+	// Timeout is the effective deadline for local Ollama calls.
+	req, err := http.NewRequestWithContext(context.Background(), "POST", c.cfg.Endpoint, bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("request creation error: %w", err)
 	}

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -364,11 +364,8 @@ func (a *Analyzer) printSummary(result *ScanResult) {
 }
 
 func summaryRepeat(ch string, n int) string {
-	out := ""
-	for i := 0; i < n; i++ {
-		out += ch
-	}
-	return out
+	// strings.Repeat is O(n) via a single allocation; += in a loop is O(n²).
+	return strings.Repeat(ch, n)
 }
 
 func printSeverityBar(label string, count int, c *color.Color, char string) {

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -240,7 +240,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 	// Exit code based on vulnerabilities found
 	if result.HasCritical() || result.HasHigh() {
 		if outputFile != "" {
-			color.Red("\n⚠  High/Critical vulnerabilities found. Check report: %s\n", outputFile)
+			// Printf-style formatting requires the color object's Printf method —
+			// the package-level color.Red is a PrintFunc (Fprint-based) and does
+			// not interpolate format verbs, so %s would be printed literally.
+			color.New(color.FgRed).Printf("\n⚠  High/Critical vulnerabilities found. Check report: %s\n", outputFile)
 		}
 		os.Exit(1)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -187,9 +187,12 @@ func buildSnippet(lines []string, lineNum, context int) string {
 // mustCompile compiles regex or returns a never-matching pattern on error.
 // The fallback uses [^\s\S] because `$^` still matches empty strings (blank
 // lines), which caused false positives for rules with invalid regex.
+// Invalid patterns are logged to stderr so rule authors are not left
+// wondering why a custom rule silently produces zero findings.
 func mustCompile(pattern string) *regexp.Regexp {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠  invalid rule pattern (rule disabled): %v\n", err)
 		return regexp.MustCompile(`[^\s\S]`) // truly never matches
 	}
 	return re

--- a/internal/monitor/webhook.go
+++ b/internal/monitor/webhook.go
@@ -128,6 +128,14 @@ func (s *webhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 
 	go func() {
+		// A panic inside scanFn must not crash the webhook server — the
+		// server is long-lived and may receive many events concurrently.
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Printf("  %s Scan panic on branch %q: %v\n",
+					color.RedString("✗"), branch, r)
+			}
+		}()
 		if err := s.scanFn(branch); err != nil {
 			fmt.Printf("  %s Scan error on branch %q: %v\n",
 				color.RedString("✗"), branch, err)

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -532,7 +532,7 @@ func (r *SARIFReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{
 					ArtifactLocation: sarifArtifactLocation{URI: sarifRelPath(result.TargetPath, f.File)},
-					Region:           sarifRegion{StartLine: f.Line, StartColumn: f.Column},
+					Region:           sarifRegion{StartLine: sarifStartLine(f.Line), StartColumn: f.Column},
 				},
 			}},
 		})
@@ -561,7 +561,7 @@ func (r *SARIFReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{
 					ArtifactLocation: sarifArtifactLocation{URI: sarifRelPath(result.TargetPath, f.File)},
-					Region:           sarifRegion{StartLine: f.Line},
+					Region:           sarifRegion{StartLine: sarifStartLine(f.Line)},
 				},
 			}},
 		})
@@ -595,6 +595,17 @@ func sarifLevel(s config.Severity) string {
 	default:
 		return "note"
 	}
+}
+
+// sarifStartLine clamps a line number to the minimum valid value for SARIF (1).
+// The SARIF 2.1 spec requires startLine >= 1; a zero value produced by a
+// finding with an unknown position would generate an invalid SARIF document
+// that GitHub's Security tab and other consumers reject.
+func sarifStartLine(line int) int {
+	if line < 1 {
+		return 1
+	}
+	return line
 }
 
 // ============= HTML REPORTER =============


### PR DESCRIPTION
## What changed and why

- **`cli/scan.go`** — replace `color.Red()` with `color.New(color.FgRed).Printf()`.
  The package-level `color.Red` is a `PrintFunc` (Fprint-based) and does not
  interpolate format verbs; `%s` was being printed literally instead of the
  report file path.

- **`analyzer/analyzer.go`** — replace `+=` loop in `summaryRepeat` with
  `strings.Repeat`. The loop caused an O(n²) allocation chain on every summary
  render; `strings.Repeat` uses a single allocation.

- **`reporter/reporter.go`** — add `sarifStartLine()` helper that clamps line
  numbers to >= 1. The SARIF 2.1 spec requires `startLine >= 1`; a zero value
  from a finding with an unknown position generates an invalid document that
  GitHub Security tab and other consumers reject silently.

- **`engine/engine.go`** — log invalid rule patterns to stderr in `mustCompile`
  instead of silently returning a never-matching regex. Rule authors had no
  feedback when a broken pattern was quietly disabled.

- **`ai/claude.go`** — replace `http.NewRequest` with `http.NewRequestWithContext`
  on both cloud and Ollama call paths. Existing security properties (redirect
  refusal, HTTPS enforcement, client-level timeout) are unaffected.

- **`monitor/webhook.go`** — add `defer recover()` inside the background scan
  goroutine. A panic in `scanFn` previously crashed the entire webhook server
  process; the server is long-lived and must survive individual scan failures.

## How it was tested

- [ ] `go build ./...` compiles without errors
- [ ] `go vet ./...` reports no issues
- [ ] `make fmt && make lint` pass
- [ ] `drogonsec scan . --format sarif` produces valid SARIF output
- [ ] `drogonsec scan . --format text --output report.txt` prints the report
  path correctly in red when HIGH/CRITICAL findings are present
- [ ] Introducing an invalid regex in a custom YAML rule prints a warning to
  stderr and does not silently skip findings
- [ ] Webhook server continues accepting events after a simulated scan panic

## Related issues

None — bugs identified during code review.