### PR TITLE
docs: OWASP-readiness — CHANGELOG, SECURITY, Code of Conduct, issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report a problem with DrogonSec
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Run `drogonsec ...`
+2. Against `...`
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include the full command and output (sanitize any
+secrets or proprietary code).
+
+## Environment
+
+- DrogonSec version (`drogonsec --version`):
+- OS and architecture:
+- Go version (if building from source):
+- Engines enabled (SAST / SCA / Leaks / IaC / AI):
+
+## Minimal Reproduction
+
+A minimal, sanitized code snippet or repository that triggers the issue.
+
+## Additional Context
+
+Anything else that helps us understand the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/filipi86/drogonsec/security/advisories/new
+    about: Please report security vulnerabilities privately, not as public issues. See SECURITY.md.
+  - name: Question / Discussion
+    url: https://github.com/filipi86/drogonsec/discussions
+    about: Ask questions and discuss ideas with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest an enhancement or new capability for DrogonSec
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem / Motivation
+
+What problem does this feature solve? Who benefits from it?
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen. If it touches a
+specific engine (SAST / SCA / Leaks / IaC / AI), say which.
+
+## Alternatives Considered
+
+Any alternative solutions or features you considered.
+
+## Additional Context
+
+Links, references, prior art (other scanners), or examples that help scope the
+work.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+Briefly describe what this PR changes and why.
+
+## Related Issues
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] New detection rule or secret pattern
+- [ ] Documentation
+- [ ] Build, CI, or dependency change
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
+- [ ] `go build ./...` and `go test ./...` pass locally
+- [ ] `gofmt` and `golangci-lint run` are clean
+- [ ] I added or updated tests where appropriate
+- [ ] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
+- [ ] My changes do not introduce new `govulncheck` findings
+
+## Notes for Reviewers
+
+Anything reviewers should pay special attention to.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to **DrogonSec** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-06-23
+
+First public release of DrogonSec, a high-performance open-source security
+scanner combining SAST, SCA, secret detection, and IaC analysis in a single
+binary, built for developers and CI/CD pipelines.
+
+### Added
+
+- **SAST engine**: static analysis with language-specific rule sets for 20+
+  languages, aligned with the OWASP Top 10:2025.
+- **SCA engine**: dependency vulnerability scanning against the OSV database,
+  with manifest parsers for npm, pip, Go, Maven, Ruby, Composer, and Dart.
+- **Secret detection**: regex and Shannon-entropy based leak detection over the
+  working tree and full git history, with per-rule confidence levels and
+  match redaction.
+- **IaC analysis**: misconfiguration checks for infrastructure-as-code.
+- **AI-powered remediation**: optional remediation suggestions via local Ollama
+  (no API key) or cloud providers (Anthropic, OpenAI-compatible, custom
+  endpoints), enabled with `--enable-ai`.
+- **Output formats**: human-readable text, JSON, native SARIF for GitHub Code
+  Scanning, and a standalone HTML report.
+- **Branch monitoring**: webhook server for scanning repositories on push.
+- **CLI**: `scan` command with per-engine toggles, severity filtering, and
+  shell completion for bash and zsh.
+- **CI/CD**: GitHub Actions pipeline with build, test, lint, govulncheck, and a
+  self-scan security gate.
+
+[Unreleased]: https://github.com/filipi86/drogonsec/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/filipi86/drogonsec/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**filipi.pires@filipipires.com**. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,9 @@ Read the full [CLA document](./CLA.md) before signing.
 
 ## Code of Conduct
 
-This project follows a **Contributor Covenant** approach. Be respectful, inclusive, and constructive. Harassment, discrimination, or bad-faith contributions will not be tolerated.
+This project adopts the [Contributor Covenant](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold it. Be respectful, inclusive, and constructive. Harassment, discrimination, or bad-faith contributions will not be tolerated. Report unacceptable behavior as described in the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+To report a **security vulnerability**, do not open a public issue — follow the private process in our [Security Policy](./SECURITY.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,9 @@ Contributions are welcome! Areas to contribute:
 - Documentation
 - Bug fixes
 
-See [CONTRIBUTING](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING](CONTRIBUTING.md) for guidelines. All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+To report a security vulnerability, please follow our [Security Policy](SECURITY.md) — do not open a public issue.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+DrogonSec is a security tool, and we take the security of the project itself
+seriously. We appreciate responsible disclosure of vulnerabilities.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | Yes       |
+
+Only the latest released minor version receives security fixes. Please upgrade
+before reporting an issue.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use one of the following private channels:
+
+1. **GitHub Security Advisories (preferred):** open a private report through the
+   [Security tab](https://github.com/filipi86/drogonsec/security/advisories/new)
+   of this repository.
+2. **Email:** send details to **filipi.pires@filipipires.com** with the subject
+   line `[DrogonSec Security]`.
+
+Please include as much of the following as you can:
+
+- The type of issue and the component affected (engine, CLI, monitor, AI client).
+- Affected version or commit hash.
+- Step-by-step instructions to reproduce.
+- A minimal proof of concept, if available.
+- The impact, including how an attacker might exploit the issue.
+
+## Response Process
+
+- We will acknowledge your report within **5 business days**.
+- We will provide an initial assessment and expected timeline within **10
+  business days**.
+- We will keep you informed of remediation progress and coordinate a disclosure
+  date with you.
+- With your permission, we will credit you in the release notes and advisory.
+
+## Scope
+
+This policy covers the DrogonSec source code and its official release artifacts.
+Findings produced *by* DrogonSec when scanning third-party code are not
+vulnerabilities in DrogonSec and should be reported to the respective projects.
+
+Thank you for helping keep DrogonSec and its users safe.


### PR DESCRIPTION
## Summary

Adds the community-health and governance files needed to submit DrogonSec as an OWASP project, and to meet standard open-source health expectations. **No code changes.**

## What's included

- **CHANGELOG.md** — Keep a Changelog format; documents the `0.1.0` initial release feature set (SAST, SCA, secret detection, IaC, AI remediation, SARIF/HTML output, branch monitoring).
- **SECURITY.md** — private vulnerability disclosure policy (GitHub Security Advisories + email), supported versions, and response SLAs. Important for a security tool.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 with an enforcement contact.
- **.github/ISSUE_TEMPLATE/** — bug report + feature request templates, plus `config.yml` routing security reports to private advisories. Also fixes the previously broken "Bug Report template" reference in `CONTRIBUTING.md`.
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist (tests, gofmt, lint, govulncheck).
- **CONTRIBUTING.md / README.md** — link the new Code of Conduct and Security Policy.

## OWASP context

This covers the **repo-side** gaps from the OWASP project criteria review. The remaining items are process-level and outside this PR: ≥2 official OWASP-member leaders, OWASP naming/branding ("OWASP DrogonSec"), vendor-neutrality, and the foundation submission itself. A `v0.1.0` release (satisfying the "≥1 release/year" rule) will follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)