### PR TITLE
fix(docker): bump builder image to golang:1.26.4-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for minimal final image
 
 # ============ BUILD STAGE ============
-FROM golang:1.25.9-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 # ENVIRONMENT is injected by CI (production | staging | development).
 # Defaults to production for plain `docker build .` invocations.


### PR DESCRIPTION
## Problem

The `Build & Push Docker` job fails on `main`:

```
go: go.mod requires go >= 1.26.4 (running go 1.25.9; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

## Cause

The toolchain bump in #32 updated `go.mod` (`go 1.26.4`) and the `setup-go` pins in the workflows, but the Dockerfile base image stayed at `golang:1.25.9-alpine`. The `sed` in that PR targeted `golang:1.25.10-alpine` (assuming #28 had bumped it), but the Dockerfile was actually still `1.25.9`, so it was left behind. Under `GOTOOLCHAIN=local` the image refuses to auto-upgrade, breaking `go mod download`.

## Fix

Bump the builder base image to `golang:1.26.4-alpine`, matching `go.mod` and the workflow `go-version` pins. The other jobs (Build & Test, Lint, Security Scan) already pass because they use `actions/setup-go@v6` with `go-version: '1.26.4'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)