### PR TITLE
fix(ci): bump golangci-lint to latest in dev/staging pipelines

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.0.0
+          version: latest

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.0.0
+          version: latest
 
   # ============ DOCKER ============
   docker:


### PR DESCRIPTION
## Problem

The Lint job in the **Development** and **Staging** pipelines has been failing on every push (going back months), independent of the code:

```
##[error]Failed to run: requested golangci-lint version 'v2.0.0' isn't supported:
we support only v2.1.0 and later versions
```

`golangci-lint-action@v9` dropped support for golangci-lint < v2.1.0, but `development.yml` and `staging.yml` still pin `version: v2.0.0`. The install step fails before any linting happens.

## Fix

Align both workflows with `ci.yml`, which already uses `version: latest` (and passes). One-line change in each workflow.

This is why syncing `development`/`staging` to `main` still showed a red Lint — the code is fine; the pinned tool version was unsupported.