### PR TITLE
fix(ci): grant packages:write to staging pipeline for GHCR push

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  packages: write          # Required for GHCR Docker push
 
 jobs:
   # ============ BUILD & TEST ============


### PR DESCRIPTION
## Problem

The Staging pipeline's **Build Docker (Staging)** job fails at push:

```
denied: installation not allowed to Write organization package
```

`staging.yml` declared only `contents: read` and `security-events: write`, so the `GITHUB_TOKEN` lacked the `packages: write` scope required to push to `ghcr.io/filipi86/drogonsec`.

## Fix

Add `packages: write` to the staging workflow permissions, mirroring `ci.yml` (which already pushes from `main` successfully).

The image **build** already works after the `golang:1.26.4-alpine` Dockerfile fix (#35); this only addresses the registry **push** permission. `development.yml` has no Docker push job, so it needs no change.