### PR TITLE
feat(docker): enable multi-platform Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -157,6 +160,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -62,6 +62,9 @@ jobs:
     name: Build Docker (Staging)
     runs-on: ubuntu-latest
     needs: [ build-test ]
+    # Publish images only on branch pushes: on pull_request this would push
+    # :staging tags to GHCR before review (and fork PRs cannot login anyway).
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -65,6 +65,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -79,6 +82,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             ENVIRONMENT=staging

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@
 # Multi-stage build for minimal final image
 
 # ============ BUILD STAGE ============
-FROM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 # ENVIRONMENT is injected by CI (production | staging | development).
 # Defaults to production for plain `docker build .` invocations.
 ARG ENVIRONMENT=production
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates make
@@ -21,7 +23,7 @@ RUN go mod download
 COPY . .
 
 # Build static binary with environment branding
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build \
     -ldflags="-w -s -extldflags '-static' -X github.com/filipi86/drogonsec/internal/cli.Environment=${ENVIRONMENT}" \
     -o /build/drogonsec \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ GO             := go
 GOFLAGS        :=
 BUILD_DIR      := ./bin
 MAIN           := ./cmd/drogonsec/main.go
+DOCKER_IMAGE   := drogonsec-scanner
+DOCKER_PLATFORMS := linux/amd64,linux/arm64
+DOCKER_OUTPUT  := type=oci,dest=$(BUILD_DIR)/$(BINARY_NAME)-docker-$(VERSION).tar
 
 .PHONY: all build clean test lint install release help
 
@@ -99,12 +102,17 @@ scan-sarif: build ## Scan and generate SARIF report (for GitHub)
 	@echo "✓ SARIF: drogonsec.sarif"
 
 ##@ Docker
-docker-build: ## Build Docker image
-	docker build -t drogonsec-scanner:$(VERSION) .
+docker-build: ## Build Docker image for linux/amd64 and linux/arm64
+	@mkdir -p $(BUILD_DIR)
+	docker buildx build --platform $(DOCKER_PLATFORMS) -t $(DOCKER_IMAGE):$(VERSION) --output $(DOCKER_OUTPUT) .
 	@echo "✓ Docker image built"
 
+docker-push: ## Build and push multi-arch Docker image (set DOCKER_IMAGE)
+	docker buildx build --platform $(DOCKER_PLATFORMS) -t $(DOCKER_IMAGE):$(VERSION) --push .
+	@echo "✓ Docker image pushed"
+
 docker-run: ## Run DrogonSec in Docker
-	docker run --rm -v $(PWD):/scan drogonsec-scanner:$(VERSION) scan /scan
+	docker run --rm -v $(PWD):/scan $(DOCKER_IMAGE):$(VERSION) scan /scan
 
 ##@ Cleanup
 clean: ## Remove build artifacts

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+go = "1.26.4"
+golangci-lint = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.26.4"
-golangci-lint = "latest"
+go = "1.26.5"
+golangci-lint = "2.12.2"


### PR DESCRIPTION
## What changed and why

Adds multi-platform Docker build support for linux/amd64 and linux/arm64.

This updates CI/staging Docker publishing to use QEMU with Buildx, configures docker/build-push-action to publish both target platforms, and removes hard-coded linux/amd64 values from the Dockerfile build stage so BuildKit can pass the target OS and architecture.

The Makefile Docker targets now use Buildx with configurable image/platform/output values, plus a push target for multi-arch image publishing.

This also adds mise tool versions so contributors can run the documented verification commands with the expected Go and golangci-lint tools.

Closes #41

## How it was tested

- mise install
- mise exec -- make fmt && mise exec -- make lint && mise exec -- make test

## Related issues

Closes #41
