### PR TITLE
feat(leaks): report the column where the secret starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Leak findings now carry the column of the secret**, in the JSON output and
+  in the SARIF region. Only SAST findings had one, so a reader of a leak had no
+  way to tell where on the line the credential sat and could only mark the line
+  as a whole — GitHub Code Scanning highlighted from column 1, and an editor
+  would underline the variable name along with everything else.
+
+### Fixed
+
+- **Columns are counted in characters rather than bytes.** A line with accented
+  text ahead of the match reported a column past where the match really starts,
+  because a multi-byte character counted once per byte. SARIF measures columns
+  in characters, and so does every editor. This affected the SAST columns that
+  already existed.
+
 ### Changed
 
 - **The banner, progress bars, scan summary and warnings now go to stderr**,

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -465,6 +465,7 @@ func leakToFinding(lf leaks.LeakFinding) LeakFinding {
 		Type:         lf.Type,
 		File:         lf.File,
 		Line:         lf.Line,
+		Column:       lf.Column,
 		Match:        lf.Match,
 		RuleID:       lf.RuleID,
 		Severity:     lf.Severity,

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -58,6 +58,7 @@ type LeakFinding struct {
 	Type          string          `json:"type"` // "AWS Key", "GitHub Token", etc.
 	File          string          `json:"file"`
 	Line          int             `json:"line"`
+	Column        int             `json:"column"`
 	Match         string          `json:"match"` // redacted value
 	RuleID        string          `json:"rule_id"`
 	Severity      config.Severity `json:"severity"`

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/filipi86/drogonsec/internal/config"
 )
@@ -199,13 +200,17 @@ func (e *Engine) RuleCount() int {
 	return len(e.rules)
 }
 
-// helper: find column of first match in line
+// helper: find column of first match in line.
+// The column is counted in characters rather than bytes, because that is how
+// SARIF and every editor read it; a line carrying accented text ahead of the
+// match would otherwise point past where the match really starts. Returns 0
+// when the rule does not match, which the reporters treat as "unknown".
 func findColumn(line string, re *regexp.Regexp) int {
 	loc := re.FindStringIndex(line)
 	if loc == nil {
 		return 0
 	}
-	return loc[0] + 1
+	return utf8.RuneCountInString(line[:loc[0]]) + 1
 }
 
 // helper: build a code snippet around a line

--- a/internal/leaks/detector.go
+++ b/internal/leaks/detector.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/filipi86/drogonsec/internal/config"
 	"github.com/go-git/go-git/v5"
@@ -21,6 +22,7 @@ type LeakFinding struct {
 	Type         string
 	File         string
 	Line         int
+	Column       int
 	Match        string
 	RuleID       string
 	Severity     config.Severity
@@ -517,6 +519,20 @@ func mustCompile(pattern string) *regexp.Regexp {
 	return re
 }
 
+// columnOf converts a byte offset within a line into a 1-based column.
+// Columns are counted in characters, not bytes: SARIF measures them that way,
+// and so does every editor, so a line with accented text ahead of the secret
+// would otherwise anchor the finding past where the secret actually starts.
+func columnOf(line string, byteOffset int) int {
+	if byteOffset <= 0 {
+		return 1
+	}
+	if byteOffset > len(line) {
+		byteOffset = len(line)
+	}
+	return utf8.RuneCountInString(line[:byteOffset]) + 1
+}
+
 // shannonEntropy calculates the Shannon entropy of a string
 func shannonEntropy(s string) float64 {
 	if len(s) == 0 {
@@ -647,10 +663,13 @@ func (d *Detector) matchLine(line string) []LeakFinding {
 
 	var findings []LeakFinding
 	for _, rule := range d.rules {
-		if !rule.Pattern.MatchString(line) {
+		// FindStringIndex gives the match and where it starts in one pass;
+		// MatchString followed by FindString ran every pattern twice.
+		loc := rule.Pattern.FindStringIndex(line)
+		if loc == nil {
 			continue
 		}
-		match := rule.Pattern.FindString(line)
+		match := line[loc[0]:loc[1]]
 
 		entropy := 0.0
 		if strings.Contains(rule.Name, "Generic") || strings.Contains(rule.Name, "High Entropy") {
@@ -662,6 +681,7 @@ func (d *Detector) matchLine(line string) []LeakFinding {
 
 		findings = append(findings, LeakFinding{
 			Type:        rule.Name,
+			Column:      columnOf(line, loc[0]),
 			Match:       redactSecret(match),
 			RuleID:      rule.ID,
 			Severity:    rule.Severity,

--- a/internal/leaks/detector_test.go
+++ b/internal/leaks/detector_test.go
@@ -114,6 +114,53 @@ func TestDetector_RedactedMatch(t *testing.T) {
 	}
 }
 
+// TestDetector_Column checks that a finding points at the secret itself rather
+// than at the start of the line, which is what lets an editor underline the
+// credential and not the variable that holds it.
+func TestDetector_Column(t *testing.T) {
+	d := leaks.NewDetector()
+
+	testCases := []struct {
+		name string
+		line string
+		want int
+	}{
+		{
+			name: "secret in the middle of the line",
+			line: "aws_access_key_id = AKIAIOSFODNN7EXAMPLE",
+			want: 21,
+		},
+		{
+			name: "secret at the start of the line",
+			line: "AKIAIOSFODNN7EXAMPLE",
+			want: 1,
+		},
+		{
+			// Columns are counted in characters, not bytes: each of the three
+			// accented characters ahead of the key takes two bytes, so a byte
+			// offset would point three columns past the secret.
+			name: "multi-byte characters before the secret",
+			line: "# café résumé key: AKIAIOSFODNN7EXAMPLE",
+			want: 20,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, f := range d.ScanLine(tc.line) {
+				if f.Type != "AWS Access Key ID" {
+					continue
+				}
+				if f.Column != tc.want {
+					t.Errorf("Column = %d, want %d", f.Column, tc.want)
+				}
+				return
+			}
+			t.Fatal("expected an AWS Access Key ID finding, got none")
+		})
+	}
+}
+
 // helper
 func getTypes(findings []leaks.LeakFinding) []string {
 	types := make([]string, len(findings))

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -564,7 +564,7 @@ func (r *SARIFReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{
 					ArtifactLocation: sarifArtifactLocation{URI: sarifRelPath(result.TargetPath, f.File)},
-					Region:           sarifRegion{StartLine: sarifStartLine(f.Line)},
+					Region:           sarifRegion{StartLine: sarifStartLine(f.Line), StartColumn: sarifStartColumn(f.Column)},
 				},
 			}},
 		})

--- a/internal/reporter/sarif_test.go
+++ b/internal/reporter/sarif_test.go
@@ -95,6 +95,7 @@ func fullResult() *analyzer.ScanResult {
 			Severity:    config.SeverityCritical,
 			File:        "/repo/config/prod.yml",
 			Line:        3,
+			Column:      12,
 			Match:       "AKI*****************",
 		}},
 		SCAFindings: []analyzer.SCAFinding{{
@@ -236,6 +237,25 @@ func TestSARIFRegionsAreValid(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestSARIFLeaksCarryTheirColumn keeps secrets anchored where they actually
+// are. Without startColumn the region runs from the start of the line, so an
+// editor underlines the whole line and points a reviewer at the variable name
+// instead of the credential.
+func TestSARIFLeaksCarryTheirColumn(t *testing.T) {
+	doc := writeSARIF(t, fullResult())
+
+	for _, res := range doc.Runs[0].Results {
+		if res.RuleID != "LEAK-001" {
+			continue
+		}
+		if got := res.Locations[0].PhysicalLocation.Region.StartColumn; got != 12 {
+			t.Errorf("leak result has startColumn %d, want 12", got)
+		}
+		return
+	}
+	t.Error("no LEAK-001 result in the emitted document")
 }
 
 func TestSARIFLevelMapping(t *testing.T) {


### PR DESCRIPTION
## Summary

Leak findings carried a file and a line but no column, so nothing downstream
could tell where on the line the credential actually sat: GitHub Code Scanning
starts the region at column 1, and an editor asked to mark the finding
underlines the whole line — variable name, quotes and trailing comment included.
SAST findings have carried a column since the beginning. This closes the gap,
and fixes how that column was measured.

A scan of a file containing `aws_access_key_id = AKIAIOSFODNN7EXAMPLE` now
reports:

```json
{ "type": "AWS Access Key ID", "line": 1, "column": 21, "rule_id": "LEAK-001" }
```

and the SARIF region reads `{"startLine": 1, "startColumn": 21}`.

Two things came out of the change:

- **Columns are now counted in characters, not bytes.** `findColumn` returned a
  byte offset, so a line with accented text ahead of the match reported the
  finding several columns to the right of where it is. SARIF measures columns in
  characters and so does every editor. This affected the SAST columns that
  already existed, so it is fixed on both sides — a document that measured its
  two engines differently would be worse than either choice alone.
- **`matchLine` no longer runs each pattern twice.** It called `MatchString` and
  then `FindString`; `FindStringIndex` returns the match and its position in one
  pass. At ~50 patterns per line the second pass was not free.

This is the last remaining item of the enabling work in the CLI for the planned
IDE extension. An extension can now anchor a secret at the exact position rather
than at column 1.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New detection rule or secret pattern
- [ ] Documentation
- [ ] Build, CI, or dependency change

The character-vs-byte correction is a bug fix that rides along; it changes
reported column numbers only on lines containing multi-byte characters.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
- [x] `go build ./...` and `go test ./...` pass locally
- [x] `gofmt` and `golangci-lint run` are clean (0 issues)
- [x] I added or updated tests where appropriate
- [x] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
- [x] My changes do not introduce new `govulncheck` findings

## Notes for Reviewers

`column` is a new field in the leak JSON output. It is additive, but anyone
parsing the JSON with a strict schema will see it.

The SAST column change is the one with a behavioural effect on existing output:
lines with multi-byte characters before the match now report a smaller,
correct column. Pure-ASCII lines — the overwhelming majority — are unchanged.

`endColumn` is deliberately not emitted, for either engine. The SARIF region
therefore starts at the secret and runs to the end of the line. Emitting it for
leaks needs a field of its own rather than the length of `Match`, since
redaction does not preserve the length of short secrets.

`govulncheck` reports 5 stdlib advisories on the local toolchain (go1.26.5, all
fixed in go1.26.6). They predate this branch and are unrelated to it.
