### PR TITLE
fix(analyzer): apply --severity to leak findings

### DIFF
--- a/.drogonsec.yaml
+++ b/.drogonsec.yaml
@@ -117,6 +117,9 @@ suppressions:
   - rule_id: "GO-005"
     file: "internal/engine/engine_test.go"
     reason: "Test fixture — InsecureSkipVerify:true embedded in a Go code string to verify GO-005 detection"
+  - rule_id: "GO-007"
+    file: "internal/engine/engine_test.go"
+    reason: "Test fixture — math/rand token generation embedded in a Go code string to verify GO-007 detection"
   # --- Detector self-matches: the leak engine's own rule definitions ---
   - rule_id: "GEN-001"
     file: "internal/leaks/detector.go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   because a multi-byte character counted once per byte. SARIF measures columns
   in characters, and so does every editor. This affected the SAST columns that
   already existed.
+- **`--severity` was ignored by the leak engine.** SAST and SCA both dropped
+  findings below the requested floor; leaks reported every finding regardless,
+  so `drogonsec scan . --severity HIGH` still returned LOW secrets. This also
+  made the test-aware demotion pointless for leaks — a secret lowered to LOW
+  because it sits in a fixture was reported anyway — and filled this project's
+  own GitHub Security tab with 30 alerts for the fake credentials that exist to
+  exercise the detectors. Leaks are now held to the same floor, in the working
+  tree and in `--git-history`.
 
 ### Changed
 
+- **Secrets on `.gitignore`d files are demoted to LOW rather than INFO.** The
+  demotion exists so a local `.env` stops inflating the CRITICAL count while
+  staying visible — a copy committed earlier in history is still a real
+  exposure ([#17](https://github.com/filipi86/drogonsec/issues/17)). INFO sits
+  below the default `--severity LOW` floor, so once leaks respect that floor an
+  INFO finding would have vanished from the default scan instead. LOW keeps the
+  finding where the issue intended it.
 - **The banner, progress bars, scan summary and warnings now go to stderr**,
   leaving stdout for what the caller asked for: the findings report, the shell
   completion script, the `version` and `rules list` output. `drogonsec scan .

--- a/docs/security.md
+++ b/docs/security.md
@@ -122,7 +122,9 @@ OSV API responses are additionally capped at `32 MiB` via `io.LimitReader` so a 
 
 ## `.gitignore` Awareness (Leaks)
 
-When `.gitignore` at the repo root matches a file, any secret finding on that file is **downgraded to INFO severity** with a marker in the description. The finding is kept visible because a historical accidental commit remains a real risk (check with `--git-history`), but it no longer generates HIGH/CRITICAL noise for files the developer explicitly excluded from version control. See [Issue #17](https://github.com/filipi86/drogonsec/issues/17).
+When `.gitignore` at the repo root matches a file, any secret finding on that file is **downgraded to LOW severity** with a marker in the description. The finding is kept visible because a historical accidental commit remains a real risk (check with `--git-history`), but it no longer generates HIGH/CRITICAL noise for files the developer explicitly excluded from version control. See [Issue #17](https://github.com/filipi86/drogonsec/issues/17).
+
+The demotion stops at LOW rather than INFO precisely so the finding stays visible: `--severity` defaults to `LOW`, and leak findings are held to that floor like every other engine, so an INFO finding would be dropped from the default scan instead of surfaced quietly.
 
 ---
 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -283,9 +283,14 @@ func (a *Analyzer) runLeakDetection(files []string, result *ScanResult) error {
 
 	detector := leaks.NewDetector()
 	// Load .gitignore from the target path so we can downgrade findings on
-	// intentionally ignored files (e.g. .env) from HIGH/CRITICAL to INFO,
+	// intentionally ignored files (e.g. .env) from HIGH/CRITICAL to LOW,
 	// keeping visibility without generating noise (Issue #17).
 	gitignore := leaks.NewGitignoreMatcher(a.cfg.TargetPath)
+
+	// Leaks are held to the same --severity floor as SAST and SCA. Without it
+	// the demotions below achieved nothing: a finding lowered to LOW because it
+	// sits in a test fixture was still reported by a scan asking for HIGH.
+	minWeight := config.Severity(a.cfg.MinSeverity).Weight()
 
 	for _, file := range files {
 		findings, err := detector.ScanFile(file)
@@ -296,20 +301,30 @@ func (a *Analyzer) runLeakDetection(files []string, result *ScanResult) error {
 				// Severity demotion (never drops — only lowers, keeping the
 				// finding auditable at lower --severity tiers):
 				//  - a secret on a .gitignored file (e.g. a local .env) is not
-				//    committed material → INFO;
+				//    committed material → LOW;
 				//  - a secret in a test/fixture file is an intentional
 				//    throwaway value used to exercise the detector, not a real
 				//    leak → LOW. Mirrors the SAST secret-family demotion.
+				//
+				// Neither goes below LOW. INFO sits under the default floor of
+				// the shipped configuration, and Issue #17 settled that a secret
+				// on a .gitignored file stays visible — a copy committed earlier
+				// in history is still a real exposure.
 				switch {
 				case ignored:
-					af.Severity = config.SeverityInfo
+					if af.Severity.Weight() > config.SeverityLow.Weight() {
+						af.Severity = config.SeverityLow
+					}
 					af.Description = "[.gitignore] " + af.Description +
-						" — file is listed in .gitignore; severity downgraded to INFO. " +
+						" — file is listed in .gitignore; severity downgraded to LOW. " +
 						"If this file was ever committed historically, run `drogonsec scan . --git-history` to check."
 				case isTestPath(af.File) && af.Severity.Weight() > config.SeverityLow.Weight():
 					af.Severity = config.SeverityLow
 					af.Description = "[test file] " + af.Description +
 						" — test/fixture path; likely an intentional fixture, downgraded to LOW."
+				}
+				if af.Severity.Weight() < minWeight {
+					continue
 				}
 				a.mu.Lock()
 				result.AddLeakFinding(af)
@@ -325,8 +340,12 @@ func (a *Analyzer) runLeakDetection(files []string, result *ScanResult) error {
 		gitFindings, err := detector.ScanGitHistory(a.cfg.TargetPath)
 		if err == nil {
 			for _, gf := range gitFindings {
+				af := leakToFinding(gf)
+				if af.Severity.Weight() < minWeight {
+					continue
+				}
 				a.mu.Lock()
-				result.AddLeakFinding(leakToFinding(gf))
+				result.AddLeakFinding(af)
 				a.mu.Unlock()
 			}
 		}

--- a/internal/analyzer/leak_severity_test.go
+++ b/internal/analyzer/leak_severity_test.go
@@ -1,0 +1,118 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/filipi86/drogonsec/internal/config"
+)
+
+// leakTree writes a target directory holding one secret that stays at its rule
+// severity and one that the test-path demotion lowers to LOW.
+func leakTree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// CRITICAL: an AWS key in ordinary configuration.
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"),
+		[]byte("aws_access_key_id: AKIAIOSFODNN7EXAMPLE\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Demoted to LOW: the same key in a test file, where it is a fixture.
+	if err := os.WriteFile(filepath.Join(dir, "creds_test.go"),
+		[]byte("const key = \"AKIAIOSFODNN7EXAMPLE\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func leakConfig(dir, minSeverity string) *config.ScanConfig {
+	return &config.ScanConfig{
+		TargetPath:  dir,
+		EnableLeaks: true,
+		MinSeverity: minSeverity,
+		MaxWorkers:  1,
+	}
+}
+
+// TestLeakFindingsRespectMinSeverity is the guarantee the leak engine was
+// missing: SAST and SCA both dropped findings below --severity while leaks
+// reported everything, so the demotions above were decorative — a fixture
+// lowered to LOW still reached a report asking for HIGH, and the scan of this
+// repository's own test files filled the GitHub Security tab with them.
+func TestLeakFindingsRespectMinSeverity(t *testing.T) {
+	dir := leakTree(t)
+
+	tests := []struct {
+		minSeverity string
+		wantFiles   []string
+	}{
+		{"LOW", []string{"config.yaml", "creds_test.go"}},
+		{"MEDIUM", []string{"config.yaml"}},
+		{"HIGH", []string{"config.yaml"}},
+		{"CRITICAL", []string{"config.yaml"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.minSeverity, func(t *testing.T) {
+			result, err := New(leakConfig(dir, tt.minSeverity)).Run()
+			if err != nil {
+				t.Fatalf("Run returned error: %v", err)
+			}
+
+			got := map[string]bool{}
+			for _, f := range result.LeakFindings {
+				got[filepath.Base(f.File)] = true
+			}
+
+			for _, want := range tt.wantFiles {
+				if !got[want] {
+					t.Errorf("--severity %s dropped the finding in %s", tt.minSeverity, want)
+				}
+				delete(got, want)
+			}
+			for extra := range got {
+				t.Errorf("--severity %s reported %s, which is below the floor",
+					tt.minSeverity, extra)
+			}
+		})
+	}
+}
+
+// TestGitignoredSecretsStayVisibleByDefault pins the resolution of Issue #17:
+// a secret on an ignored file is demoted so it stops inflating the CRITICAL
+// count, but it is still reported, because a copy committed earlier in history
+// is a real exposure. Demoting it to INFO would now hide it altogether — the
+// shipped default floor is LOW.
+func TestGitignoredSecretsStayVisibleByDefault(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.env\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "local.env"),
+		[]byte("AWS_SECRET=AKIAIOSFODNN7EXAMPLE\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := New(leakConfig(dir, "LOW")).Run()
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var found bool
+	for _, f := range result.LeakFindings {
+		if filepath.Base(f.File) != "local.env" {
+			continue
+		}
+		found = true
+		if f.Severity != config.SeverityLow {
+			t.Errorf("gitignored secret has severity %s, want LOW: anything lower "+
+				"falls below the default floor and disappears from the report",
+				f.Severity)
+		}
+	}
+	if !found {
+		t.Error("the secret on the gitignored file was not reported at all")
+	}
+}


### PR DESCRIPTION
## Summary

`--severity` was ignored by one of the three engines. SAST and SCA both drop
findings below the requested floor; the leak engine added every finding it
produced, so `drogonsec scan . --severity HIGH` still returned LOW secrets.

The test-aware demotion sitting directly above that call was therefore
decorative for leaks: a secret lowered to LOW *because it sits in a test
fixture* was reported all the same.

This is the cause of the 30 open alerts in this repository's own Security tab.
CI scans with `--severity MEDIUM`, and all 30 were the deliberately fake
credentials in `_test.go` files — already demoted to LOW, uploaded anyway.
Scanning a tree of only the tracked files, as CI does:

| | before | after |
|---|---|---|
| SARIF results at `--severity MEDIUM` | 31 | **0** |
| findings at `--severity LOW` | 36 | 36 |

Nothing is silently dropped — every finding is still there at the LOW tier, in
line with the project's rule that a finding is demoted, never discarded.

## Related Issues

Completes the intent of #17. Clears the 30 open code scanning alerts, which
GitHub closes on its own once an analysis of `main` stops reporting them.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New detection rule or secret pattern
- [ ] Documentation
- [ ] Build, CI, or dependency change

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
- [x] `go build ./...` and `go test ./...` pass locally
- [x] `gofmt` and `golangci-lint run` are clean (0 issues)
- [x] I added or updated tests where appropriate
- [x] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
- [x] My changes do not introduce new `govulncheck` findings

## Notes for Reviewers

**The one decision worth checking.** Secrets on `.gitignore`d files move from
INFO to LOW. Gating without that change would have hidden them from the default
scan, since `--severity` defaults to `LOW` and INFO sits below it — the opposite
of what #17 settled. Your resolution comment on that issue says the finding
"stays visible because a historical accidental commit is still a real risk", and
`docs/security.md` said the same; the doc is updated to match the new tier. LOW
keeps them out of the CRITICAL count *and* in the report.

Both tests fail on the unfixed code — verified by stashing the change and
re-running, not by inspection.

The two remaining alerts were GO-007 matching its own test fixture. That is a
suppression entry in `.drogonsec.yaml`, scoped to the one rule and file, next to
the JAVA-003 and GO-005 entries already there for the same reason.

Independent of #52; either can merge first.
