### PR TITLE
chore(deps): move the build to Go 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Download dependencies
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Build DrogonSec
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       # The tag is passed explicitly: actions/checkout does a shallow clone, so
       # the `git describe` the Makefile falls back to cannot see the tag.

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Download dependencies
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Download dependencies
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this — stderr goes to the terminal, so an interactive run looks exactly as it
   did.
 
+### Security
+
+- **The build moves to Go 1.26.6**, in CI, in the Docker image and as the floor
+  in `go.mod`. Five advisories in the standard library — `net/http`,
+  `crypto/tls`, `net/url` and `encoding/asn1` — are reachable from the monitor's
+  HTTP client, the webhook server and the SCA client, and all five are fixed in
+  1.26.6. `govulncheck` reports zero affecting the code after the bump; it had
+  started failing the build on `main` as the advisories were published, without
+  any change to the source.
+
 ## [0.3.0] - 2026-08-13
 
 Correctness release for the SCA engine. Writing the first tests for it turned

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for minimal final image
 
 # ============ BUILD STAGE ============
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 
 # ENVIRONMENT is injected by CI (production | staging | development).
 # Defaults to production for plain `docker build .` invocations.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filipi86/drogonsec
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
## Summary

`main` is red, and no source change caused it: five standard-library advisories
were published against go1.26.5, which every workflow pins. All five are
reachable from this code —

| Advisory | Package | Reached through |
|---|---|---|
| GO-2026-6218 | `net/url` | `monitor.gitlabClient.GetBranchSHA` |
| GO-2026-6090 | `crypto/tls` | `monitor.webhookServer.Start` |
| GO-2026-6089 | `net/http` | `monitor.webhookServer.Start` |
| GO-2026-5972 | `encoding/asn1` | TLS handshake in the webhook server |
| GO-2026-5026 | `net/http` | `ai.Client.CheckHealth`, `sca.osvClient` |

— and all five are fixed in 1.26.6.

Bumped in the three workflows, the Dockerfile and `go.mod`. After the bump:

```
Your code is affected by 0 vulnerabilities.
```

## Related Issues

Unblocks #53, and any other PR, since `Build & Test` is a required check.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New detection rule or secret pattern
- [ ] Documentation
- [x] Build, CI, or dependency change

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
- [x] `go build ./...` and `go test ./...` pass locally
- [x] `gofmt` and `golangci-lint run` are clean
- [x] I added or updated tests where appropriate (n/a — toolchain bump)
- [x] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
- [x] My changes do not introduce new `govulncheck` findings

## Notes for Reviewers

The `go.mod` directive is bumped alongside CI deliberately. It is the only part
that reaches beyond this repository's runners: it stops a contributor from
building a security scanner against a standard library with five known
vulnerabilities. The cost is that 1.26.6 becomes the minimum to build.

The remaining advisory govulncheck still lists in a required module is the
`x/crypto` openpgp one already documented in `.drogonsec.yaml` — unmaintained
upstream, no fixed version, never called from here.

Worth deciding separately: Dependabot covers actions and Go modules but not the
`go-version` pin, so the next stdlib advisory will fail the build the same way.
