### PR TITLE
docs: correct the JSON schema and the required Go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ To report a **security vulnerability**, do not open a public issue — follow th
 
 | Tool | Version |
 |------|---------|
-| Go | 1.25+ |
+| Go | 1.26.6+ |
 | Git | any recent |
 | golangci-lint | latest (optional, for linting) |
 | Docker | optional |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI/CD](https://github.com/filipi86/drogonsec/actions/workflows/ci.yml/badge.svg)](https://github.com/filipi86/drogonsec/actions)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![OWASP Top 10 2025](https://img.shields.io/badge/OWASP-Top%2010%3A2025-orange.svg)](https://owasp.org/Top10/2025/)
-[![Go 1.25+](https://img.shields.io/badge/Go-1.25+-00ADD8.svg)](https://golang.org)
+[![Go 1.26.6+](https://img.shields.io/badge/Go-1.26.6+-00ADD8.svg)](https://golang.org)
 [![GitHub Release](https://img.shields.io/github/v/release/filipi86/drogonsec)](https://github.com/filipi86/drogonsec/releases)
 [![GitHub Issues](https://img.shields.io/github/issues/filipi86/drogonsec)](https://github.com/filipi86/drogonsec/issues)
 
@@ -49,7 +49,7 @@
 
 ### Installation
 
-**Go Install (requires Go 1.25+):**
+**Go Install (requires Go 1.26.6+):**
 ```bash
 go install github.com/filipi86/drogonsec/cmd/drogonsec@latest
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![CI/CD](https://github.com/filipi86/drogonsec/actions/workflows/ci.yml/badge.svg)](https://github.com/filipi86/drogonsec/actions)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![OWASP Top 10 2025](https://img.shields.io/badge/OWASP-Top%2010%3A2025-orange.svg)](https://owasp.org/Top10/2025/)
-[![Go 1.25+](https://img.shields.io/badge/Go-1.25+-00ADD8.svg)](https://golang.org)
+[![Go 1.26.6+](https://img.shields.io/badge/Go-1.26.6+-00ADD8.svg)](https://golang.org)
 [![GitHub Release](https://img.shields.io/github/v/release/filipi86/drogonsec)](https://github.com/filipi86/drogonsec/releases)
 [![GitHub Issues](https://img.shields.io/github/issues/filipi86/drogonsec)](https://github.com/filipi86/drogonsec/issues)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ Before installing Drogonsec, make sure you have the following on your system:
 
 | Requirement | Minimum Version | Notes |
 |---|---|---|
-| **Go** | 1.25+ | [Download Go](https://golang.org/dl/) |
+| **Go** | 1.26.6+ | [Download Go](https://golang.org/dl/) |
 | **Git** | any | For cloning the repository |
 | **Make** | any | For using the build system |
 | **Docker** | any | Optional — for container-based usage |
@@ -22,7 +22,7 @@ go version
 Expected output:
 
 ```
-go version go1.25.x linux/amd64
+go version go1.26.6 linux/amd64
 ```
 
 ---
@@ -45,7 +45,7 @@ After a successful build, verify the binary:
 
 ---
 
-## Method 2 — Go Install (Requires Go 1.25+)
+## Method 2 — Go Install (Requires Go 1.26.6+)
 
 Install directly from the module without cloning the repository:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -288,7 +288,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.6'
 
       - name: Install Drogonsec
         run: |
@@ -388,31 +388,70 @@ With `fail_on.critical: true`, Drogonsec exits with a non-zero code when critica
 ```json
 {
   "version": "0.3.0",
+  "scan_time": "2026-08-14T09:41:02Z",
+  "duration": "1.204s",
   "target": "./myproject",
   "stats": {
-    "total_findings": 3,
+    "total_findings": 2,
     "critical": 1,
-    "high": 2,
+    "high": 1,
     "medium": 0,
-    "low": 0
+    "low": 0,
+    "info": 0,
+    "sast_count": 1,
+    "sca_count": 0,
+    "leaks_count": 1
   },
   "sast_findings": [
     {
-      "id": "PY-001",
+      "id": "PY-001-users.py-42",
+      "type": "SAST",
+      "language": "Python",
       "severity": "HIGH",
       "title": "SQL Injection via string formatting",
+      "description": "Direct string interpolation in SQL queries allows SQL Injection attacks. Attackers can manipulate queries to access or modify unauthorized data.",
       "file": "src/users.py",
       "line": 42,
-      "owasp": "A05:2025",
+      "column": 5,
+      "code": "def get_user(user_id):\n    cursor.execute(\"SELECT * FROM users WHERE id = %s\" % user_id)\n",
+      "rule_id": "PY-001",
+      "owasp": "A05:2025 - Injection",
       "cwe": "CWE-89",
       "cvss": 9.8,
-      "fix": "Use parameterized queries"
+      "references": [
+        "https://owasp.org/Top10/2025/A05_2025-Injection/",
+        "https://cwe.mitre.org/data/definitions/89.html"
+      ],
+      "remediation": "Use parameterized queries or prepared statements. Example: cursor.execute('SELECT * FROM users WHERE id = ?', (user_id,))",
+      "false_positive": false
     }
   ],
-  "leak_findings": [],
-  "sca_findings": []
+  "sca_findings": [],
+  "leak_findings": [
+    {
+      "type": "AWS Access Key ID",
+      "file": "src/config.py",
+      "line": 1,
+      "column": 12,
+      "match": "AKI*****************",
+      "rule_id": "LEAK-001",
+      "severity": "CRITICAL",
+      "description": "AWS Access Key ID detected. This grants programmatic access to AWS services."
+    }
+  ]
 }
 ```
+
+Notes for anyone parsing this output:
+
+- `id` is unique per finding (`<rule>-<file>-<line>`); the rule itself is `rule_id`.
+  Group and suppress on `rule_id`, not on `id`.
+- `column` is 1-based and counted in **characters**, not bytes.
+- `match` on a leak finding is always redacted — the raw secret is never written
+  to any report.
+- `ai_remediation` appears on a finding only when `--enable-ai` produced one, and
+  `dependencies` appears at the top level only when the SCA engine ran.
+- Findings arrive ordered by severity, CRITICAL first.
 
 ---
 


### PR DESCRIPTION
## Summary

Two documentation defects, both of the kind that costs somebody real time.

**The documented JSON schema was wrong.** `docs/usage.md` showed an example with
fields the scanner does not emit. Anyone writing a parser from it got three
things wrong:

| documented | actual |
|---|---|
| `"id": "PY-001"` | `id` is `PY-001-users.py-42`; the rule is `rule_id` |
| `"fix": "…"` | the field is `remediation` |
| `"owasp": "A05:2025"` | `"A05:2025 - Injection"` |

It also omitted `type`, `language`, `description`, `column`, `code`,
`references` and `false_positive`, and left `leak_findings` empty — so the shape
of a leak finding, including the `column` added in #52, appeared nowhere in the
documentation. The replacement example is copied from a real scan rather than
written by hand, and is followed by short parsing notes: which identifier is
stable to group on, that columns are 1-based and counted in characters, that
`match` is always redacted, and which fields are conditional.

**The required Go version was stale in seven places** — the README and docs
badges, both install sections, the requirements tables in `installation.md` and
`CONTRIBUTING.md`, and the Actions example in `usage.md` — all reading 1.25+
while `go.mod` has required 1.26 for a while and, with #54, requires 1.26.6.
With the default `GOTOOLCHAIN=auto` a user on 1.25 silently downloads a newer
toolchain; with `GOTOOLCHAIN=local`, or in an air-gapped runner, `go install`
just fails against what the README promised.

## Related Issues

None. Documents the `column` field from #52 and the toolchain floor from #54.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New detection rule or secret pattern
- [x] Documentation
- [ ] Build, CI, or dependency change

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
- [x] `go build ./...` and `go test ./...` pass locally
- [x] `gofmt` and `golangci-lint run` are clean
- [x] I added or updated tests where appropriate (n/a — no code changes)
- [x] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
- [x] My changes do not introduce new `govulncheck` findings

## Notes for Reviewers

**Merge after #54.** The stated floor of 1.26.6 only becomes true when that PR
lands; everything else here is independent.

No `CHANGELOG.md` entry: this documents behavior that already shipped rather
than changing any, and three open PRs editing the same `Unreleased` block is how
the conflict on #53 happened. Say the word if you would rather it be recorded.

The JSON example keeps `"version": "0.3.0"` and illustrative paths, but every
field name and every enum value in it came out of an actual run.
