### PR TITLE
feat(sca): read package-lock.json and report the dependency path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`package-lock.json` is parsed, so npm projects are scanned in full.** The
+  SCA engine read `package.json` alone, which lists what a project declared, at
+  version ranges. Everything those dependencies pull in — the overwhelming
+  majority of installed code, and where most advisories land — was invisible.
+  On a project whose only declared dependency is `express@4.17.1`, DrogonSec
+  saw 1 package and now sees 50, reporting 12 vulnerabilities where it
+  previously reported 2. All three lockfile formats are handled: the nested
+  tree of npm 6 and the flat `packages` map of npm 7 and later.
+- **Findings say how a package got there.** Every SCA finding now carries
+  `direct` and, when it is not direct, `dependency_path` — the chain that
+  introduces it, shown in the terminal report as `Required : via express`. A
+  vulnerability in a package a project never named is not fixed by upgrading
+  that package, and the chain names what has to move instead.
+- **Versions are the ones actually installed.** A range like `^4.17.1` is not a
+  version and cannot be matched against an advisory; reading the lockfile
+  replaces the guess with the resolved version, which removes false positives
+  and false negatives at the same time.
+
+### Fixed
+
+- **The same vulnerability could be reported twice.** OSV holds some flaws under
+  several identifiers that alias one another — `path-to-regexp` 0.1.7 comes back
+  as both `GHSA-37ch-88jc-xwx2` and `GHSA-9wv6-86v2-598j`, each listing the
+  other, both resolving to `CVE-2024-45296`. Findings are now collapsed by
+  package, version, manifest and CVE, falling back to the advisory identifier
+  for advisories that never received a CVE.
+- **The documented SCA support was aspirational.** `docs/modules.md` listed
+  `yarn.lock`, `Pipfile.lock`, `pyproject.toml`, `go.sum`, Gradle builds,
+  `composer.lock`, `Cargo.lock` and the whole .NET ecosystem as supported. None
+  of them were parsed. The table now states what the engine reads, how deep it
+  goes for each ecosystem, and what is not covered.
+
+### Added
+
 - **Leak findings now carry the column of the secret**, in the JSON output and
   in the SARIF region. Only SAST findings had one, so a reader of a leak had no
   way to tell where on the line the credential sat and could only mark the line

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -78,16 +78,31 @@ The SCA engine scans your project's dependency manifest files for known CVEs, ou
 
 ### Supported Manifest Files
 
-| Ecosystem | Files |
-|---|---|
-| **Node.js** | `package.json`, `package-lock.json`, `yarn.lock` |
-| **Python** | `requirements.txt`, `Pipfile`, `Pipfile.lock`, `pyproject.toml` |
-| **Go** | `go.mod`, `go.sum` |
-| **Java** | `pom.xml`, `build.gradle`, `build.gradle.kts` |
-| **Ruby** | `Gemfile`, `Gemfile.lock` |
-| **PHP** | `composer.json`, `composer.lock` |
-| **Rust** | `Cargo.toml`, `Cargo.lock` |
-| **.NET** | `*.csproj`, `packages.config` |
+| Ecosystem | Files | Depth |
+|---|---|---|
+| **Node.js** | `package-lock.json`, `package.json` | Full tree when the lockfile is present |
+| **Python** | `requirements.txt`, `requirements-dev.txt` | Declared only |
+| **Go** | `go.mod` | Declared, including `// indirect` entries |
+| **Java** | `pom.xml` | Declared only |
+| **Ruby** | `Gemfile.lock` | Full tree |
+| **PHP** | `composer.json` | Declared only |
+| **Dart** | `pubspec.yaml`, `pubspec.yml` | Declared only |
+
+**Depth is the column that matters.** A manifest states what a project asked
+for: a handful of names, at version *ranges*. A lockfile states what was
+actually installed: an exact version for every package in the tree, including
+the ones nobody named. Vulnerabilities overwhelmingly live in that second
+group, so an ecosystem marked "declared only" is reporting on a fraction of the
+code that ships.
+
+Where both exist for the same project, the lockfile wins and the manifest is
+ignored — otherwise every declared dependency would be counted twice, the
+second time at a range that matches no advisory.
+
+Not yet parsed, so a project relying on one of these is **not** covered by the
+ecosystem's row above: `yarn.lock`, `pnpm-lock.yaml`, `poetry.lock`,
+`Pipfile.lock`, `composer.lock`, `Cargo.lock`, `go.sum`, Gradle builds, and the
+.NET ecosystem entirely.
 
 ### What the SCA Engine Reports
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -114,7 +114,7 @@ When `--output <file>` is used for `text`, `json`, `sarif`, `html`, or `cycloned
 
 ## Manifest Size Limits (SCA)
 
-The SCA engine parses `package.json`, `composer.json`, `pubspec.yaml`, `Gemfile.lock`, `requirements.txt`, `go.mod`, and `pom.xml`. JSON/YAML parsers load the full file before validating structure, so DrogonSec enforces a `10 MiB` size cap per manifest before parsing. Custom YAML rule files (loaded via `--rules-dir`) are capped at `5 MiB`. This prevents a malicious or accidentally oversized manifest from OOM-killing the scanner in CI.
+The SCA engine parses `package-lock.json`, `package.json`, `composer.json`, `pubspec.yaml`, `Gemfile.lock`, `requirements.txt`, `go.mod`, and `pom.xml`. JSON/YAML parsers load the full file before validating structure, so DrogonSec enforces a `10 MiB` size cap per manifest before parsing. Custom YAML rule files (loaded via `--rules-dir`) are capped at `5 MiB`. This prevents a malicious or accidentally oversized manifest from OOM-killing the scanner in CI.
 
 OSV API responses are additionally capped at `32 MiB` via `io.LimitReader` so a compromised or misbehaving OSV proxy cannot exhaust scanner memory by streaming gigabytes of data.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -451,6 +451,11 @@ Notes for anyone parsing this output:
   to any report.
 - `ai_remediation` appears on a finding only when `--enable-ai` produced one, and
   `dependencies` appears at the top level only when the SCA engine ran.
+- On an SCA finding, `direct` says whether the project declares the package
+  itself, and `dependency_path` is the chain that introduced it otherwise
+  (`["express", "qs"]` means express requires qs which requires this package).
+  A transitive finding with an empty path is one whose route could not be
+  established — usually an ecosystem scanned without its lockfile.
 - Findings arrive ordered by severity, CRITICAL first.
 
 ---

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -41,6 +41,18 @@ type SCAFinding struct {
 	Description    string               `json:"description"`
 	Advisory       string               `json:"advisory_url"`
 	OWASP          config.OWASPCategory `json:"owasp"`
+
+	// Direct is false when nothing in the project declares this package: it
+	// arrived because another dependency required it. DependencyPath is the
+	// chain that introduces it, from a declared dependency inwards and
+	// excluding the package itself, so ["express", "cookie"] means express
+	// requires cookie which requires this package. Both are empty when the
+	// ecosystem's lockfile was absent and only declared dependencies could be
+	// read.
+	//
+	// Converted directly from sca.Finding — keep the fields in step.
+	Direct         bool     `json:"direct"`
+	DependencyPath []string `json:"dependency_path,omitempty"`
 }
 
 // Dependency represents a single component discovered by the SCA engine.

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -388,6 +388,11 @@ func (r *TextReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 			)
 			fmt.Fprintf(w, "  CVE      : %s  CVSS: %.1f\n", f.CVE, f.CVSS)
 			fmt.Fprintf(w, "  Manifest : %s\n", f.ManifestFile)
+			// Whether the project asked for this package decides what can be
+			// done about it. A direct dependency is a version bump; a
+			// transitive one usually is not, and the route names the package
+			// that has to move instead.
+			fmt.Fprintf(w, "  Required : %s\n", dependencyOrigin(f))
 			fmt.Fprintf(w, "  Fixed in : %s\n", green(f.FixedVersion))
 			fmt.Fprintf(w, "  Desc     : %s\n", f.Description)
 			fmt.Fprintf(w, "  Advisory : %s\n", f.Advisory)
@@ -395,6 +400,24 @@ func (r *TextReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 	}
 
 	return nil
+}
+
+// dependencyOrigin describes how a vulnerable package came to be installed.
+//
+// "directly" means the project declares it and the fix is its own version.
+// Otherwise the chain names what pulled it in, innermost last, because the
+// package to upgrade is somewhere along that chain rather than the one the
+// advisory is written about. An empty chain on a transitive package means the
+// route could not be established — the manifest was read without its lockfile,
+// or the lockfile keeps an entry nothing currently reaches.
+func dependencyOrigin(f analyzer.SCAFinding) string {
+	if f.Direct {
+		return "directly by this project"
+	}
+	if len(f.DependencyPath) == 0 {
+		return "indirectly (route unknown)"
+	}
+	return "via " + strings.Join(f.DependencyPath, " → ")
 }
 
 // ============= JSON REPORTER =============

--- a/internal/sca/engine.go
+++ b/internal/sca/engine.go
@@ -25,6 +25,17 @@ type Finding struct {
 	Description    string
 	Advisory       string
 	OWASP          config.OWASPCategory
+
+	// Direct and DependencyPath carry the shape of the dependency graph
+	// through to the report. They are what turns "you have 340 vulnerabilities"
+	// into something a team can act on: a vulnerability in a package the
+	// project never named is not fixed by upgrading that package, it is fixed —
+	// if at all — by moving whatever pulled it in.
+	//
+	// analyzer.SCAFinding is converted from this type directly, so the two
+	// declarations have to stay field-for-field identical.
+	Direct         bool
+	DependencyPath []string
 }
 
 // Dependency represents a parsed dependency
@@ -33,6 +44,20 @@ type Dependency struct {
 	Version   string
 	Ecosystem string
 	File      string
+
+	// Direct records whether the project declares this dependency itself.
+	// Everything else arrived because something else asked for it, which is
+	// where most vulnerabilities live and where the fix is rarely a version
+	// bump of the package named in the advisory.
+	Direct bool
+
+	// Path is the chain of packages that introduces a transitive dependency,
+	// from a direct dependency inwards and excluding the dependency itself:
+	// ["express", "cookie"] means express depends on cookie which depends on
+	// this one. Empty for a direct dependency, and empty when the route cannot
+	// be established. It answers the first question anyone asks about an
+	// advisory in a package they have never heard of.
+	Path []string
 }
 
 // ManifestParser defines the interface for manifest file parsers
@@ -59,6 +84,7 @@ func New(targetPath string) *Engine {
 // registerParsers adds all manifest parsers
 func (e *Engine) registerParsers() {
 	e.parsers = []ManifestParser{
+		&PackageLockParser{},
 		&PackageJSONParser{},
 		&PomXMLParser{},
 		&RequirementsTXTParser{},
@@ -93,7 +119,41 @@ func (e *Engine) Analyze() ([]Finding, error) {
 		findings = e.checkKnownVulnerabilities(deps)
 	}
 
-	return findings, nil
+	return dedupeFindings(findings), nil
+}
+
+// dedupeFindings collapses records that describe the same vulnerability in the
+// same package.
+//
+// OSV frequently holds one flaw under several identifiers that alias each
+// other — path-to-regexp 0.1.7 comes back as both GHSA-37ch-88jc-xwx2 and
+// GHSA-9wv6-86v2-598j, each listing the other and both resolving to
+// CVE-2024-45296. Reporting that twice inflates the count and costs a reviewer
+// the time it takes to work out the two entries are one issue.
+//
+// A CVE identifies the flaw, so it is the key wherever there is one. Advisories
+// that never received a CVE fall back to their advisory URL, which keeps two
+// genuinely different GHSA-only records apart. The manifest is part of the key
+// so that the same package vulnerable in two projects of a monorepo is still
+// reported for each.
+func dedupeFindings(findings []Finding) []Finding {
+	seen := make(map[string]bool, len(findings))
+	kept := make([]Finding, 0, len(findings))
+
+	for _, f := range findings {
+		identity := f.CVE
+		if identity == "" {
+			identity = f.Advisory
+		}
+		key := strings.Join([]string{f.Ecosystem, f.PackageName, f.PackageVersion, f.ManifestFile, identity}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		kept = append(kept, f)
+	}
+
+	return kept
 }
 
 // Dependencies returns the full set of dependencies discovered by the most
@@ -103,11 +163,23 @@ func (e *Engine) Dependencies() []Dependency {
 	return e.lastDeps
 }
 
-// collectDependencies finds and parses all manifest files
+// collectDependencies finds and parses all manifest files.
+//
+// Where a lockfile and a manifest describe the same project, only the lockfile
+// is kept: it names every installed package at the version actually installed,
+// while the manifest repeats the handful the project declared, at a range.
+// Merging the two would report the same direct dependency twice and match the
+// second copy against a range like "^4.17.1", which is neither a version that
+// exists nor one an advisory can be checked against.
 func (e *Engine) collectDependencies() ([]Dependency, error) {
-	var allDeps []Dependency
+	var lockfileDeps, manifestDeps []Dependency
+
+	// Directories where a lockfile has already spoken for an ecosystem.
+	locked := make(map[string]bool)
 
 	for _, parser := range e.parsers {
+		_, isLockfile := parser.(LockfileParser)
+
 		for _, manifestName := range parser.Files() {
 			err := filepath.WalkDir(e.targetPath, func(path string, d os.DirEntry, err error) error {
 				if err != nil || d.IsDir() {
@@ -121,12 +193,30 @@ func (e *Engine) collectDependencies() ([]Dependency, error) {
 					}
 				}
 
-				if filepath.Base(path) == manifestName {
-					deps, parseErr := parser.Parse(path)
-					if parseErr == nil {
-						allDeps = append(allDeps, deps...)
-					}
+				if filepath.Base(path) != manifestName {
+					return nil
 				}
+
+				deps, parseErr := parser.Parse(path)
+				if parseErr != nil {
+					return nil
+				}
+
+				if isLockfile {
+					for _, dep := range deps {
+						locked[lockKey(path, dep.Ecosystem)] = true
+					}
+					lockfileDeps = append(lockfileDeps, deps...)
+					return nil
+				}
+
+				// A manifest states intent, so everything it lists is by
+				// definition declared by the project. Lockfile parsers work the
+				// direct/transitive split out for themselves.
+				for i := range deps {
+					deps[i].Direct = true
+				}
+				manifestDeps = append(manifestDeps, deps...)
 				return nil
 			})
 			if err != nil {
@@ -135,7 +225,19 @@ func (e *Engine) collectDependencies() ([]Dependency, error) {
 		}
 	}
 
-	return allDeps, nil
+	for _, dep := range manifestDeps {
+		if locked[lockKey(dep.File, dep.Ecosystem)] {
+			continue
+		}
+		lockfileDeps = append(lockfileDeps, dep)
+	}
+
+	return lockfileDeps, nil
+}
+
+// lockKey identifies an ecosystem within one project directory.
+func lockKey(manifestPath, ecosystem string) string {
+	return filepath.Dir(manifestPath) + "\x00" + ecosystem
 }
 
 // countUniqueFiles returns the number of unique manifest files
@@ -227,6 +329,8 @@ func (e *Engine) checkKnownVulnerabilities(deps []Dependency) []Finding {
 						Description:    vuln.desc,
 						Advisory:       fmt.Sprintf("https://osv.dev/vulnerability/%s", vuln.cve),
 						OWASP:          config.OWASP_A03_SoftwareSupplyChainFailures,
+						Direct:         dep.Direct,
+						DependencyPath: dep.Path,
 					})
 				}
 			}

--- a/internal/sca/lockfiles.go
+++ b/internal/sca/lockfiles.go
@@ -1,0 +1,331 @@
+package sca
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// LockfileParser is a ManifestParser that reads a resolved dependency graph
+// rather than a declaration of intent.
+//
+// The difference decides what a scan can report. A manifest states what the
+// project asked for — "express": "^4.17.1" — which is a range, not a version,
+// and it lists only what the project asked for directly. A lockfile states what
+// was actually installed: an exact version for every package in the tree,
+// including the ones no human ever named. Vulnerabilities overwhelmingly live
+// in that second group, so a scanner reading only manifests reports on a small
+// fraction of the code that ships.
+//
+// The engine treats the two differently: when a lockfile covers a directory,
+// the manifest for the same ecosystem in that directory is discarded rather
+// than merged, because the manifest would otherwise contribute the same direct
+// dependencies a second time, at a range instead of a version.
+type LockfileParser interface {
+	ManifestParser
+
+	// Lockfile marks the implementation. It exists to be type-asserted for and
+	// carries no value of its own.
+	Lockfile()
+}
+
+// ============= npm =============
+
+// PackageLockParser parses npm's package-lock.json in all three of its
+// formats. Lockfile version 1 (npm 6) keys a nested tree under "dependencies";
+// versions 2 and 3 (npm 7 and later) key a flat map under "packages" by
+// installation path. Version 2 carries both for backward compatibility, and
+// the flat map is preferred when present because it records the root project's
+// own declarations, which is what makes a direct dependency distinguishable
+// from a hoisted transitive one.
+type PackageLockParser struct{}
+
+func (p *PackageLockParser) Name() string    { return "npm (lockfile)" }
+func (p *PackageLockParser) Files() []string { return []string{"package-lock.json"} }
+func (p *PackageLockParser) Lockfile()       {}
+
+// packageLock covers the parts of package-lock.json this parser reads. Fields
+// absent from a given lockfile version simply stay empty.
+type packageLock struct {
+	LockfileVersion int                    `json:"lockfileVersion"`
+	Packages        map[string]lockEntryV3 `json:"packages"`
+	Dependencies    map[string]lockEntryV1 `json:"dependencies"`
+}
+
+// lockEntryV3 is one entry of the v2/v3 "packages" map, keyed by installation
+// path ("node_modules/express", "node_modules/express/node_modules/cookie").
+type lockEntryV3 struct {
+	Version              string            `json:"version"`
+	Link                 bool              `json:"link"`
+	Dependencies         map[string]string `json:"dependencies"`
+	DevDependencies      map[string]string `json:"devDependencies"`
+	OptionalDependencies map[string]string `json:"optionalDependencies"`
+}
+
+// lockEntryV1 is one node of the v1 "dependencies" tree. It nests: a package
+// whose own requirement conflicts with the hoisted version gets its private
+// copy under the parent's "dependencies".
+type lockEntryV1 struct {
+	Version      string                 `json:"version"`
+	Requires     map[string]string      `json:"requires"`
+	Dependencies map[string]lockEntryV1 `json:"dependencies"`
+}
+
+// node is the shape both lockfile formats are normalised into before the graph
+// is walked: an installation path, a resolved version, and the names this node
+// depends on. Reducing v1 and v3 to the same shape means the traversal that
+// works out what is reachable, and by which route, is written once.
+type node struct {
+	name    string
+	version string
+	deps    map[string]string
+}
+
+func (p *PackageLockParser) Parse(path string) ([]Dependency, error) {
+	data, err := readManifestFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lock packageLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return nil, err
+	}
+
+	nodes, roots := normaliseNPMLock(&lock, path)
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+
+	return walkNPMGraph(nodes, roots, path), nil
+}
+
+// normaliseNPMLock reduces either lockfile layout to the common node map, and
+// returns the names the root project declares for itself.
+func normaliseNPMLock(lock *packageLock, path string) (map[string]node, []string) {
+	if len(lock.Packages) > 0 {
+		return normaliseV3(lock)
+	}
+	return normaliseV1(lock, path)
+}
+
+func normaliseV3(lock *packageLock) (map[string]node, []string) {
+	nodes := make(map[string]node, len(lock.Packages))
+	var roots []string
+
+	for key, entry := range lock.Packages {
+		// The empty key is the project itself: it holds no version of interest,
+		// only the list of what the project actually asked for. That list is
+		// the sole way to tell a direct dependency from a transitive one that
+		// npm hoisted to the top of node_modules alongside it.
+		if key == "" {
+			roots = append(roots, mapKeys(entry.Dependencies)...)
+			roots = append(roots, mapKeys(entry.DevDependencies)...)
+			roots = append(roots, mapKeys(entry.OptionalDependencies)...)
+			continue
+		}
+		// Workspace members are symlinks into the repository, not published
+		// packages, and carry no version to match an advisory against.
+		if entry.Link || entry.Version == "" || !strings.Contains(key, "node_modules/") {
+			continue
+		}
+
+		deps := make(map[string]string, len(entry.Dependencies)+len(entry.OptionalDependencies))
+		for n, v := range entry.Dependencies {
+			deps[n] = v
+		}
+		for n, v := range entry.OptionalDependencies {
+			deps[n] = v
+		}
+
+		nodes[key] = node{name: npmNameFromKey(key), version: entry.Version, deps: deps}
+	}
+
+	sort.Strings(roots)
+	return nodes, roots
+}
+
+// normaliseV1 flattens the nested v1 tree into the same path-keyed map the v3
+// layout already uses, so one traversal serves both. A v1 lockfile does not
+// record what the project declared, so the sibling package.json is consulted
+// for that; without it every package is reported, but none can be called
+// direct.
+func normaliseV1(lock *packageLock, path string) (map[string]node, []string) {
+	nodes := make(map[string]node)
+
+	var flatten func(prefix string, entries map[string]lockEntryV1)
+	flatten = func(prefix string, entries map[string]lockEntryV1) {
+		for name, entry := range entries {
+			key := prefix + "node_modules/" + name
+			if entry.Version != "" {
+				nodes[key] = node{name: name, version: entry.Version, deps: entry.Requires}
+			}
+			if len(entry.Dependencies) > 0 {
+				flatten(key+"/", entry.Dependencies)
+			}
+		}
+	}
+	flatten("", lock.Dependencies)
+
+	return nodes, npmRootsFromPackageJSON(filepath.Join(filepath.Dir(path), "package.json"))
+}
+
+// npmRootsFromPackageJSON reads the names the project declares. A missing or
+// unreadable package.json is not an error: the lockfile still describes every
+// installed package, and the only thing lost is the direct/transitive split.
+func npmRootsFromPackageJSON(path string) []string {
+	data, err := readManifestFile(path)
+	if err != nil {
+		return nil
+	}
+	var pkg struct {
+		Dependencies         map[string]string `json:"dependencies"`
+		DevDependencies      map[string]string `json:"devDependencies"`
+		OptionalDependencies map[string]string `json:"optionalDependencies"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+	roots := append(mapKeys(pkg.Dependencies), mapKeys(pkg.DevDependencies)...)
+	roots = append(roots, mapKeys(pkg.OptionalDependencies)...)
+	sort.Strings(roots)
+	return roots
+}
+
+// walkNPMGraph breadth-first searches from the declared dependencies, so the
+// route recorded for a package is the shortest one that introduces it. That is
+// the route worth showing: it answers "why is this in my tree" with the fewest
+// hops, and it is the hop nearest the root that a developer can actually
+// change.
+//
+// Packages the search never reaches are still reported, with no route. A lock
+// file can retain entries for a platform the current install skipped, and a
+// vulnerability in one of those is not made harmless by the graph edge being
+// absent from this file.
+func walkNPMGraph(nodes map[string]node, roots []string, manifest string) []Dependency {
+	type queued struct {
+		key  string
+		path []string
+	}
+
+	seen := make(map[string]bool, len(nodes))
+	deps := make([]Dependency, 0, len(nodes))
+	var queue []queued
+
+	for _, name := range roots {
+		if key, ok := resolveNPM(nodes, "", name); ok && !seen[key] {
+			seen[key] = true
+			deps = append(deps, Dependency{
+				Name:      nodes[key].name,
+				Version:   nodes[key].version,
+				Ecosystem: "npm",
+				File:      manifest,
+				Direct:    true,
+			})
+			queue = append(queue, queued{key: key, path: []string{nodes[key].name}})
+		}
+	}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		for _, name := range sortedKeys(nodes[current.key].deps) {
+			key, ok := resolveNPM(nodes, current.key, name)
+			if !ok || seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			// The route is the parent's route; the package itself is the
+			// destination, not part of the path leading to it.
+			route := make([]string, len(current.path))
+			copy(route, current.path)
+
+			deps = append(deps, Dependency{
+				Name:      nodes[key].name,
+				Version:   nodes[key].version,
+				Ecosystem: "npm",
+				File:      manifest,
+				Path:      route,
+			})
+			queue = append(queue, queued{key: key, path: append(route, nodes[key].name)})
+		}
+	}
+
+	for _, key := range sortedKeys(nodes) {
+		if seen[key] {
+			continue
+		}
+		deps = append(deps, Dependency{
+			Name:      nodes[key].name,
+			Version:   nodes[key].version,
+			Ecosystem: "npm",
+			File:      manifest,
+		})
+	}
+
+	return deps
+}
+
+// resolveNPM finds which installed package a dependency edge points at, by the
+// rule Node itself uses: look inside the dependent's own node_modules first,
+// then walk up towards the root, taking the first match. This is what makes
+// two versions of the same package resolvable — a nested copy shadows the
+// hoisted one for whatever required it.
+func resolveNPM(nodes map[string]node, from, name string) (string, bool) {
+	prefix := from
+	for {
+		candidate := "node_modules/" + name
+		if prefix != "" {
+			candidate = prefix + "/node_modules/" + name
+		}
+		if _, ok := nodes[candidate]; ok {
+			return candidate, true
+		}
+		// The root's own node_modules is the last place to look, and it is
+		// where npm hoists almost everything: a tree with no version conflicts
+		// is entirely flat. Stopping before trying it — which is what happens
+		// if the walk-up only ever strips "/node_modules/" components — leaves
+		// every transitive package unreachable and therefore unattributed.
+		if prefix == "" {
+			return "", false
+		}
+		if cut := strings.LastIndex(prefix, "/node_modules/"); cut >= 0 {
+			prefix = prefix[:cut]
+		} else {
+			prefix = ""
+		}
+	}
+}
+
+// npmNameFromKey recovers a package name from its installation path. Splitting
+// on the last "node_modules/" keeps scoped names intact: the "/" inside
+// "@scope/pkg" is not a path separator here.
+func npmNameFromKey(key string) string {
+	if i := strings.LastIndex(key, "node_modules/"); i >= 0 {
+		return key[i+len("node_modules/"):]
+	}
+	return key
+}
+
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// sortedKeys keeps the traversal deterministic. Go randomises map iteration,
+// and without an order the reported route for a package reachable by several
+// equally short paths would differ between runs of the same scan.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/sca/lockfiles_test.go
+++ b/internal/sca/lockfiles_test.go
@@ -1,0 +1,411 @@
+package sca
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/filipi86/drogonsec/internal/config"
+)
+
+// writeFiles creates a set of files in one fresh temporary directory, keyed by
+// relative name, and returns the directory. Lockfile parsing depends on what
+// sits next to the lockfile, so the fixtures need more than a single file.
+func writeFiles(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("creating directory for %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+// lockV3 is an npm 7+ lockfile. express is the only declared dependency;
+// everything else is hoisted alongside it, which is exactly the layout that
+// makes "which of these did I ask for" impossible to answer from the key alone.
+const lockV3 = `{
+  "name": "app",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "app",
+      "dependencies": { "express": "^4.17.1" },
+      "devDependencies": { "jest": "^29.0.0" }
+    },
+    "node_modules/express": {
+      "version": "4.17.1",
+      "dependencies": { "cookie": "0.4.0", "qs": "6.7.0" }
+    },
+    "node_modules/cookie": { "version": "0.4.0" },
+    "node_modules/qs": {
+      "version": "6.7.0",
+      "dependencies": { "side-channel": "1.0.4" }
+    },
+    "node_modules/side-channel": { "version": "1.0.4" },
+    "node_modules/jest": { "version": "29.7.0" },
+    "node_modules/@scope/util": { "version": "2.1.0" },
+    "node_modules/orphan": { "version": "9.9.9" },
+    "node_modules/app-workspace": { "resolved": "packages/app", "link": true },
+    "node_modules/no-version": { "resolved": "https://example.test/x.tgz" }
+  }
+}`
+
+func TestPackageLockV3(t *testing.T) {
+	dir := writeFiles(t, map[string]string{"package-lock.json": lockV3})
+
+	deps, err := (&PackageLockParser{}).Parse(filepath.Join(dir, "package-lock.json"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	t.Run("reports every installed package, not only the declared ones", func(t *testing.T) {
+		want := []string{"@scope/util", "cookie", "express", "jest", "orphan", "qs", "side-channel"}
+		if got := depNames(deps); !reflect.DeepEqual(got, want) {
+			t.Errorf("parsed %v, want %v", got, want)
+		}
+	})
+
+	t.Run("only what the project declares is direct", func(t *testing.T) {
+		for _, name := range []string{"express", "jest"} {
+			d, ok := findDep(deps, name)
+			if !ok {
+				t.Fatalf("%s missing", name)
+			}
+			if !d.Direct {
+				t.Errorf("%s should be direct: the root entry declares it", name)
+			}
+		}
+		// A hoisted transitive package sits at the same depth in node_modules
+		// as a declared one. Calling it direct would tell a reader to upgrade a
+		// package their project never names.
+		for _, name := range []string{"cookie", "qs", "side-channel"} {
+			d, _ := findDep(deps, name)
+			if d.Direct {
+				t.Errorf("%s is hoisted, not declared, and must not be direct", name)
+			}
+		}
+	})
+
+	t.Run("the route records how a package was introduced", func(t *testing.T) {
+		tests := []struct {
+			name string
+			want []string
+		}{
+			{"express", nil},
+			{"cookie", []string{"express"}},
+			{"qs", []string{"express"}},
+			{"side-channel", []string{"express", "qs"}},
+		}
+		for _, tt := range tests {
+			d, ok := findDep(deps, tt.name)
+			if !ok {
+				t.Fatalf("%s missing", tt.name)
+			}
+			if !reflect.DeepEqual(d.Path, tt.want) {
+				t.Errorf("%s route = %v, want %v", tt.name, d.Path, tt.want)
+			}
+		}
+	})
+
+	t.Run("resolved versions, never ranges", func(t *testing.T) {
+		// The root entry asks for "^4.17.1". Matching that against an advisory
+		// is meaningless: it is not a version that exists.
+		d, _ := findDep(deps, "express")
+		if d.Version != "4.17.1" {
+			t.Errorf("express version = %q, want the resolved 4.17.1", d.Version)
+		}
+	})
+
+	t.Run("scoped names survive the path split", func(t *testing.T) {
+		if _, ok := findDep(deps, "@scope/util"); !ok {
+			t.Error(`@scope/util was lost: the "/" inside a scope is not a path separator`)
+		}
+	})
+
+	t.Run("unreachable packages are still reported", func(t *testing.T) {
+		// A lockfile keeps entries for platforms the current install skipped.
+		// A vulnerability in one of those is not made harmless by the edge
+		// being absent from this file, so it is reported with no route.
+		d, ok := findDep(deps, "orphan")
+		if !ok {
+			t.Fatal("orphan was dropped; an unreachable package is still installed code")
+		}
+		if d.Direct || len(d.Path) != 0 {
+			t.Errorf("orphan should carry no route, got direct=%v path=%v", d.Direct, d.Path)
+		}
+	})
+
+	t.Run("workspace links and versionless entries are skipped", func(t *testing.T) {
+		for _, name := range []string{"app-workspace", "no-version"} {
+			if _, ok := findDep(deps, name); ok {
+				t.Errorf("%s has no published version to match an advisory against", name)
+			}
+		}
+	})
+}
+
+// TestPackageLockNestedShadowing covers the case the whole resolution rule
+// exists for: two versions of one package in the same tree. Node resolves from
+// the dependent's own node_modules outwards, so the nested copy is what the
+// parent actually loads — and reporting the hoisted version against it would
+// name a version that code never runs.
+func TestPackageLockNestedShadowing(t *testing.T) {
+	dir := writeFiles(t, map[string]string{"package-lock.json": `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "dependencies": { "alpha": "1.0.0", "beta": "1.0.0" } },
+	    "node_modules/alpha": { "version": "1.0.0", "dependencies": { "ms": "2.0.0" } },
+	    "node_modules/alpha/node_modules/ms": { "version": "2.0.0" },
+	    "node_modules/beta": { "version": "1.0.0", "dependencies": { "ms": "2.1.3" } },
+	    "node_modules/ms": { "version": "2.1.3" }
+	  }
+	}`})
+
+	deps, err := (&PackageLockParser{}).Parse(filepath.Join(dir, "package-lock.json"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	var versions []string
+	for _, d := range deps {
+		if d.Name == "ms" {
+			versions = append(versions, d.Version)
+		}
+	}
+	if len(versions) != 2 {
+		t.Fatalf("got ms %v, want both installed copies (2.0.0 and 2.1.3)", versions)
+	}
+
+	for _, d := range deps {
+		if d.Name != "ms" {
+			continue
+		}
+		switch d.Version {
+		case "2.0.0":
+			if !reflect.DeepEqual(d.Path, []string{"alpha"}) {
+				t.Errorf("nested ms 2.0.0 route = %v, want [alpha]", d.Path)
+			}
+		case "2.1.3":
+			if len(d.Path) != 1 || (d.Path[0] != "beta" && d.Path[0] != "alpha") {
+				t.Errorf("hoisted ms 2.1.3 route = %v, want a single-hop route", d.Path)
+			}
+		}
+	}
+}
+
+// TestPackageLockV1 covers npm 6, whose lockfile nests the tree and never
+// records what the project declared.
+func TestPackageLockV1(t *testing.T) {
+	lock := `{
+	  "lockfileVersion": 1,
+	  "dependencies": {
+	    "express": {
+	      "version": "4.17.1",
+	      "requires": { "cookie": "0.4.0" }
+	    },
+	    "cookie": { "version": "0.4.0" },
+	    "nested-parent": {
+	      "version": "1.0.0",
+	      "requires": { "shared": "1.0.0" },
+	      "dependencies": {
+	        "shared": { "version": "1.0.0" }
+	      }
+	    }
+	  }
+	}`
+
+	t.Run("the sibling package.json supplies what the lockfile omits", func(t *testing.T) {
+		dir := writeFiles(t, map[string]string{
+			"package-lock.json": lock,
+			"package.json":      `{"dependencies": {"express": "^4.17.1", "nested-parent": "^1.0.0"}}`,
+		})
+
+		deps, err := (&PackageLockParser{}).Parse(filepath.Join(dir, "package-lock.json"))
+		if err != nil {
+			t.Fatalf("Parse returned error: %v", err)
+		}
+
+		if d, _ := findDep(deps, "express"); !d.Direct {
+			t.Error("express is declared in package.json and should be direct")
+		}
+		if d, _ := findDep(deps, "cookie"); d.Direct {
+			t.Error("cookie is required by express, not declared")
+		}
+		if d, _ := findDep(deps, "cookie"); !reflect.DeepEqual(d.Path, []string{"express"}) {
+			t.Errorf("cookie route = %v, want [express]", d.Path)
+		}
+		if d, _ := findDep(deps, "shared"); !reflect.DeepEqual(d.Path, []string{"nested-parent"}) {
+			t.Errorf("nested shared route = %v, want [nested-parent]", d.Path)
+		}
+	})
+
+	t.Run("without a package.json every package is still reported", func(t *testing.T) {
+		dir := writeFiles(t, map[string]string{"package-lock.json": lock})
+
+		deps, err := (&PackageLockParser{}).Parse(filepath.Join(dir, "package-lock.json"))
+		if err != nil {
+			t.Fatalf("Parse returned error: %v", err)
+		}
+
+		// Losing the direct/transitive split is acceptable; losing the packages
+		// would mean reporting nothing for a repository that vendors its
+		// lockfile without its manifest.
+		want := []string{"cookie", "express", "nested-parent", "shared"}
+		if got := depNames(deps); !reflect.DeepEqual(got, want) {
+			t.Errorf("parsed %v, want %v", got, want)
+		}
+		for _, d := range deps {
+			if d.Direct {
+				t.Errorf("%s cannot be known to be direct with no package.json", d.Name)
+			}
+		}
+	})
+}
+
+// TestLockfileTakesPrecedenceOverManifest pins the rule that keeps the two npm
+// parsers from double-counting. Without it every declared dependency is
+// reported twice: once at its resolved version and once at the range the
+// manifest asked for, and the range matches no advisory.
+func TestLockfileTakesPrecedenceOverManifest(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"package-lock.json":      lockV3,
+		"package.json":           `{"dependencies": {"express": "^4.17.1"}}`,
+		"other/package.json":     `{"dependencies": {"lodash": "4.17.15"}}`,
+		"other/requirements.txt": "flask==2.0.0\n",
+	})
+
+	deps, err := New(dir).collectDependencies()
+	if err != nil {
+		t.Fatalf("collectDependencies returned error: %v", err)
+	}
+
+	var expressCount int
+	for _, d := range deps {
+		if d.Name == "express" {
+			expressCount++
+			if d.Version != "4.17.1" {
+				t.Errorf("express version = %q, want the lockfile's resolved 4.17.1", d.Version)
+			}
+		}
+	}
+	if expressCount != 1 {
+		t.Errorf("express reported %d times, want once — the manifest copy should be dropped", expressCount)
+	}
+
+	// A directory the lockfile does not cover keeps its manifest, and so does
+	// an unrelated ecosystem: precedence is per directory and per ecosystem,
+	// not global.
+	if d, ok := findDep(deps, "lodash"); !ok || !d.Direct {
+		t.Error("a package.json in a directory with no lockfile must still be parsed")
+	}
+	if _, ok := findDep(deps, "flask"); !ok {
+		t.Error("a different ecosystem must not be suppressed by an npm lockfile")
+	}
+}
+
+// TestPackageLockIsDeterministic guards against Go's randomised map iteration
+// reaching the output. A route that changes between runs of an unchanged scan
+// makes every diff between two reports untrustworthy.
+func TestPackageLockIsDeterministic(t *testing.T) {
+	dir := writeFiles(t, map[string]string{"package-lock.json": lockV3})
+	path := filepath.Join(dir, "package-lock.json")
+
+	first, err := (&PackageLockParser{}).Parse(path)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		again, err := (&PackageLockParser{}).Parse(path)
+		if err != nil {
+			t.Fatalf("Parse returned error: %v", err)
+		}
+		if !reflect.DeepEqual(first, again) {
+			t.Fatalf("run %d differs from the first:\n%+v\n%+v", i+1, first, again)
+		}
+	}
+}
+
+// TestDedupeFindings covers OSV holding one flaw under several identifiers that
+// alias each other. path-to-regexp 0.1.7 really does come back as both
+// GHSA-37ch-88jc-xwx2 and GHSA-9wv6-86v2-598j, each listing the other, and both
+// resolving to CVE-2024-45296.
+func TestDedupeFindings(t *testing.T) {
+	finding := func(pkg, version, cve, advisory, manifest string) Finding {
+		return Finding{
+			PackageName:    pkg,
+			PackageVersion: version,
+			Ecosystem:      "npm",
+			ManifestFile:   manifest,
+			CVE:            cve,
+			Advisory:       advisory,
+			Severity:       config.SeverityHigh,
+		}
+	}
+
+	tests := []struct {
+		name string
+		in   []Finding
+		want int
+	}{
+		{
+			name: "the same CVE under two advisory ids is one vulnerability",
+			in: []Finding{
+				finding("path-to-regexp", "0.1.7", "CVE-2024-45296", "https://osv.dev/vulnerability/GHSA-37ch-88jc-xwx2", "a/package-lock.json"),
+				finding("path-to-regexp", "0.1.7", "CVE-2024-45296", "https://osv.dev/vulnerability/GHSA-9wv6-86v2-598j", "a/package-lock.json"),
+			},
+			want: 1,
+		},
+		{
+			name: "different CVEs in one package are different vulnerabilities",
+			in: []Finding{
+				finding("path-to-regexp", "0.1.7", "CVE-2024-45296", "x", "a/package-lock.json"),
+				finding("path-to-regexp", "0.1.7", "CVE-2024-52798", "y", "a/package-lock.json"),
+			},
+			want: 2,
+		},
+		{
+			name: "advisories with no CVE are kept apart by their own id",
+			in: []Finding{
+				finding("left-pad", "1.0.0", "", "https://osv.dev/vulnerability/GHSA-aaaa", "a/package-lock.json"),
+				finding("left-pad", "1.0.0", "", "https://osv.dev/vulnerability/GHSA-bbbb", "a/package-lock.json"),
+			},
+			want: 2,
+		},
+		{
+			name: "the same package vulnerable in two projects is reported for each",
+			in: []Finding{
+				finding("qs", "6.7.0", "CVE-2022-24999", "x", "api/package-lock.json"),
+				finding("qs", "6.7.0", "CVE-2022-24999", "x", "web/package-lock.json"),
+			},
+			want: 2,
+		},
+		{
+			name: "two versions of one package are two findings",
+			in: []Finding{
+				finding("ms", "2.0.0", "CVE-2017-16113", "x", "a/package-lock.json"),
+				finding("ms", "2.1.3", "CVE-2017-16113", "x", "a/package-lock.json"),
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dedupeFindings(tt.in); len(got) != tt.want {
+				var ids []string
+				for _, f := range got {
+					ids = append(ids, f.PackageName+"@"+f.PackageVersion+" "+f.CVE)
+				}
+				t.Errorf("kept %d findings (%s), want %d", len(got), strings.Join(ids, ", "), tt.want)
+			}
+		})
+	}
+}

--- a/internal/sca/osv.go
+++ b/internal/sca/osv.go
@@ -371,6 +371,8 @@ func osvVulnToFinding(v osvVuln, dep Dependency) Finding {
 		Description:    desc,
 		Advisory:       fmt.Sprintf("https://osv.dev/vulnerability/%s", v.ID),
 		OWASP:          config.OWASP_A03_SoftwareSupplyChainFailures,
+		Direct:         dep.Direct,
+		DependencyPath: dep.Path,
 	}
 }
 


### PR DESCRIPTION
## Summary

The SCA engine read `package.json`, which lists what a project *declared*, at
version *ranges*. Everything those dependencies pull in was invisible — and that
is nearly all of the code that ships, and where the overwhelming majority of
advisories land.

Measured on a real project whose only declared dependency is `express@4.17.1`:

| | before | after |
|---|---|---|
| packages seen | 1 | **50** |
| vulnerabilities reported | 2 | **12** |
| of which transitive | 0 | **10** |

The ten that were missing are not noise. They are `CVE-2024-45590` in
body-parser, `CVE-2024-45296` and `CVE-2024-52798` in path-to-regexp,
`CVE-2022-24999` in qs, `CVE-2024-47764` in cookie — real advisories against code
the project ships and could not see.

Findings now carry the shape of the graph, so the report says what can be done
about each one:

```
  #1 [CRITICAL] body-parser 1.19.0
  CVE      : CVE-2024-45590  CVSS: 9.0
  Required : via express
  Fixed in : 1.20.3
```

A vulnerability in a package nobody named is not fixed by upgrading that
package. `direct` and `dependency_path` are in the JSON output too.

## Related Issues

None. Implements the transitive-dependency gap discussed with the maintainer.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New detection rule or secret pattern
- [x] Documentation
- [ ] Build, CI, or dependency change

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
- [x] `go build ./...` and `go test ./...` pass locally
- [x] `gofmt` and `golangci-lint run` are clean (0 issues)
- [x] I added or updated tests where appropriate
- [x] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
- [x] My changes do not introduce new `govulncheck` findings (0 affecting the code)

## Notes for Reviewers

**Two bugs surfaced by validating against a real lockfile rather than a
hand-written fixture.** Both are worth knowing about:

*Resolution never reached the root.* The walk-up only stripped
`/node_modules/` components, and a top-level key like `node_modules/express`
contains none, so the search gave up before trying the hoisted location — which
is where a conflict-free tree keeps everything. The first run attributed **zero**
of 49 transitive packages. Fixed by descending to the root and trying it before
failing.

*OSV can return one flaw twice.* `path-to-regexp` 0.1.7 comes back as both
`GHSA-37ch-88jc-xwx2` and `GHSA-9wv6-86v2-598j`, each listing the other as an
alias, both resolving to `CVE-2024-45296`. Findings are collapsed by package,
version, manifest and CVE, falling back to the advisory id so two different
advisories with no CVE stay apart. **This bug predates the branch** — it was
invisible while the affected packages were never scanned at all.

**Resolution follows Node's own rule** — the dependent's `node_modules` first,
then outwards — so a nested copy shadows the hoisted one for whatever required
it, and two versions of one package are reported as the two distinct installs
they are. The traversal is breadth-first, so a route is the shortest one that
introduces the package: the hop nearest the root is the one a developer can
change. Iteration is over sorted keys, because a route that changed between runs
of an unchanged scan would make every report diff untrustworthy — there is a
test that runs the parser nine times and compares.

**Lockfile beats manifest, per directory and per ecosystem.** Merging them would
report every declared dependency twice, the second time at `^4.17.1`, which is
not a version and matches no advisory. A `package.json` elsewhere in the tree, or
a different ecosystem alongside, is untouched.

**`docs/modules.md` was advertising coverage that did not exist**: `yarn.lock`,
`Pipfile.lock`, `pyproject.toml`, `go.sum`, Gradle, `composer.lock`,
`Cargo.lock` and the entire .NET ecosystem were listed as supported and none
were parsed. The table now states what is read, how deep it goes per ecosystem,
and what is not covered. For a security tool, claiming coverage you do not have
is worse than claiming less.

**Scope.** npm only, deliberately. The `LockfileParser` interface and the
precedence rule are the reusable parts; `yarn.lock`, `pnpm-lock.yaml`,
`poetry.lock`, `composer.lock` and `Cargo.lock` follow the same pattern and are
each a self-contained follow-up.
