### PR TITLE
feat(sca): read node_modules when no lockfile is committed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`node_modules/` is read when a project commits no lockfile.** Such a
+  repository was scanned from `package.json` alone — its declared dependencies,
+  at ranges — so everything they pull in was invisible, and the scan reported
+  almost nothing while succeeding. The installed tree on disk answers the same
+  question a lockfile does, exactly: on a project declaring only
+  `express@4.17.1` with its lockfile deleted, 12 vulnerabilities are found
+  instead of 2, and the SBOM lists 52 components instead of 1. Sources are tried
+  in order — `package-lock.json`, `yarn.lock`, `node_modules/`, `package.json` —
+  and none of them touches the network.
+
 - **`yarn.lock` is parsed, in both of its formats** — the bespoke text of Yarn 1
   and the YAML of Yarn 2 and later. A yarn project was previously read from its
   `package.json` alone, so it had the same blind spot npm projects had: on a

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -80,7 +80,7 @@ The SCA engine scans your project's dependency manifest files for known CVEs, ou
 
 | Ecosystem | Files | Depth |
 |---|---|---|
-| **Node.js** | `package-lock.json`, `yarn.lock`, `package.json` | Full tree when a lockfile is present |
+| **Node.js** | `package-lock.json`, `yarn.lock`, `node_modules/`, `package.json` | Full tree |
 | **Python** | `requirements.txt`, `requirements-dev.txt` | Declared only |
 | **Go** | `go.mod` | Declared, including `// indirect` entries |
 | **Java** | `pom.xml` | Declared only |
@@ -105,6 +105,22 @@ read from `package-lock.json`.
 the YAML of Yarn 2 and later. Neither records which packages the project itself
 declared, so the sibling `package.json` supplies that; without one every package
 is still reported and only the direct/transitive split is lost.
+
+For npm the engine falls back through three sources, in this order:
+
+1. **A lockfile** — `package-lock.json`, then `yarn.lock`. What *will* be
+   installed, reproducibly.
+2. **`node_modules/` on disk** — what *is* installed. Read only when no lockfile
+   covers the project, which makes a repository that does not commit one
+   scannable in full: a CI job that runs `npm ci` before the scan, or any
+   working copy after an install. Each installed package carries its own
+   manifest with a resolved version, and the directory layout is the resolution.
+3. **`package.json`** — the declared dependencies, at ranges. The last resort,
+   and the only one that leaves the transitive tree unseen.
+
+None of the three touches the network. Resolving ranges against a registry would
+answer a different question — what would be installed today — and would put a
+scan that currently runs air-gapped on the far side of the internet.
 
 Not yet parsed, so a project relying on one of these is **not** covered by the
 ecosystem's row above: `pnpm-lock.yaml`, `poetry.lock`, `Pipfile.lock`,

--- a/internal/sca/engine.go
+++ b/internal/sca/engine.go
@@ -241,6 +241,24 @@ func (e *Engine) collectDependencies() ([]Dependency, error) {
 		}
 	}
 
+	// Second source of truth, for projects that do not commit a lockfile: the
+	// tree already installed on disk. It is read only where no lockfile spoke,
+	// because a lockfile describes what will be installed reproducibly, while
+	// node_modules describes one machine's current state — which may be stale,
+	// and is absent altogether until somebody runs an install.
+	for _, dir := range npmProjectDirs(manifestDeps) {
+		key := lockKey(filepath.Join(dir, "package.json"), "npm")
+		if locked[key] {
+			continue
+		}
+		installed, err := parseInstalledNodeModules(dir)
+		if err != nil || len(installed) == 0 {
+			continue
+		}
+		locked[key] = true
+		lockfileDeps = append(lockfileDeps, installed...)
+	}
+
 	for _, dep := range manifestDeps {
 		if locked[lockKey(dep.File, dep.Ecosystem)] {
 			continue

--- a/internal/sca/installed.go
+++ b/internal/sca/installed.go
@@ -1,0 +1,155 @@
+package sca
+
+import (
+	"encoding/json"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// maxInstalledPackages caps how many packages are read out of an installed
+// tree. A node_modules directory of a large monorepo can hold tens of
+// thousands, and reading every manifest in one is work with a falling return:
+// past this point the scan is spending real time to add packages that a
+// lockfile would have described for free.
+const maxInstalledPackages = 20000
+
+// parseInstalledNodeModules reads the dependency tree from node_modules on
+// disk.
+//
+// It exists for the case a lockfile cannot cover: a repository that does not
+// commit one. Without it such a project is scanned from package.json alone —
+// its declared dependencies, at ranges — and everything those pull in is
+// invisible, which is most of the code it ships. The scan succeeds, reports
+// almost nothing, and the silence reads as safety.
+//
+// What is on disk is not a guess. Each installed package carries its own
+// manifest with a resolved version, and the directory layout is the resolution:
+// node_modules/express/node_modules/ms is a private copy that shadows the
+// hoisted one for express. That is the same shape package-lock.json v3 records,
+// so the graph walk written for it applies unchanged.
+//
+// This is deliberately not a network operation. Resolving ranges against a
+// registry would produce a tree for what would be installed today, which is a
+// different question from what is installed, and it would put a scan that
+// currently runs in an air-gapped network on the far side of the internet.
+func parseInstalledNodeModules(projectDir string) ([]Dependency, error) {
+	root := filepath.Join(projectDir, "node_modules")
+
+	nodes := make(map[string]node)
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // an unreadable subtree is skipped, not fatal
+		}
+		if d.IsDir() {
+			// .bin holds symlinked executables, and dot-directories hold
+			// package-manager bookkeeping. Neither contains packages.
+			if name := d.Name(); name != "node_modules" && strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "package.json" {
+			return nil
+		}
+		if len(nodes) >= maxInstalledPackages {
+			return filepath.SkipAll
+		}
+
+		key, ok := installedKey(projectDir, filepath.Dir(path))
+		if !ok {
+			return nil
+		}
+
+		data, err := readManifestFile(path)
+		if err != nil {
+			return nil
+		}
+		var pkg struct {
+			Name                 string            `json:"name"`
+			Version              string            `json:"version"`
+			Dependencies         map[string]string `json:"dependencies"`
+			OptionalDependencies map[string]string `json:"optionalDependencies"`
+		}
+		if err := json.Unmarshal(data, &pkg); err != nil {
+			return nil
+		}
+		if pkg.Name == "" || pkg.Version == "" {
+			return nil
+		}
+
+		deps := make(map[string]string, len(pkg.Dependencies)+len(pkg.OptionalDependencies))
+		for n, v := range pkg.Dependencies {
+			deps[n] = v
+		}
+		for n, v := range pkg.OptionalDependencies {
+			deps[n] = v
+		}
+
+		nodes[key] = node{name: pkg.Name, version: pkg.Version, deps: deps}
+		return nil
+	})
+	if err != nil || len(nodes) == 0 {
+		return nil, err
+	}
+
+	resolve := func(from, name, _ string) (string, bool) {
+		return resolveNPM(nodes, from, name)
+	}
+	// The findings are attributed to package.json: it is the file a reader can
+	// open, and node_modules is a build product rather than something in the
+	// repository.
+	manifest := filepath.Join(projectDir, "package.json")
+	roots := declaredInPackageJSON(manifest)
+
+	return walkGraph(nodes, roots, resolve, "npm", manifest), nil
+}
+
+// installedKey turns the directory a package occupies into the node_modules
+// path key the resolver expects, and rejects anything that is not a package
+// root. A manifest can sit anywhere inside a package — node_modules/foo/lib/
+// package.json is common — and treating one as an installed package would
+// invent a dependency that does not exist.
+func installedKey(projectDir, packageDir string) (string, bool) {
+	rel, err := filepath.Rel(projectDir, packageDir)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+
+	parts := strings.Split(rel, "/")
+	if len(parts) < 2 {
+		return "", false
+	}
+
+	// node_modules/<name>
+	if parts[len(parts)-2] == "node_modules" {
+		return rel, true
+	}
+	// node_modules/@scope/<name>
+	if len(parts) >= 3 && parts[len(parts)-3] == "node_modules" && strings.HasPrefix(parts[len(parts)-2], "@") {
+		return rel, true
+	}
+	return "", false
+}
+
+// npmProjectDirs lists, in a stable order, the directories holding an npm
+// manifest.
+func npmProjectDirs(deps []Dependency) []string {
+	seen := make(map[string]bool)
+	var dirs []string
+	for _, dep := range deps {
+		if dep.Ecosystem != "npm" {
+			continue
+		}
+		dir := filepath.Dir(dep.File)
+		if !seen[dir] {
+			seen[dir] = true
+			dirs = append(dirs, dir)
+		}
+	}
+	sort.Strings(dirs)
+	return dirs
+}

--- a/internal/sca/installed_test.go
+++ b/internal/sca/installed_test.go
@@ -1,0 +1,205 @@
+package sca
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// installedTree lays out a node_modules directory the way npm does: everything
+// hoisted to the top except the copy express needs privately, which sits inside
+// its own node_modules and shadows the hoisted one.
+func installedTree(t *testing.T) string {
+	t.Helper()
+	return writeFiles(t, map[string]string{
+		"package.json": `{"name":"app","dependencies":{"express":"^4.17.1"},"devDependencies":{"jest":"^29.0.0"}}`,
+
+		"node_modules/express/package.json": `{"name":"express","version":"4.17.1",
+		  "dependencies":{"accepts":"~1.3.7","ms":"2.0.0"}}`,
+		"node_modules/express/node_modules/ms/package.json": `{"name":"ms","version":"2.0.0"}`,
+
+		"node_modules/accepts/package.json": `{"name":"accepts","version":"1.3.8",
+		  "dependencies":{"mime-types":"~2.1.34"}}`,
+		"node_modules/mime-types/package.json":  `{"name":"mime-types","version":"2.1.35"}`,
+		"node_modules/ms/package.json":          `{"name":"ms","version":"2.1.3"}`,
+		"node_modules/jest/package.json":        `{"name":"jest","version":"29.7.0"}`,
+		"node_modules/@babel/core/package.json": `{"name":"@babel/core","version":"7.20.0"}`,
+
+		// Not packages: a manifest deep inside one, and a package-manager
+		// bookkeeping directory.
+		"node_modules/express/lib/package.json":    `{"name":"express-internal","version":"9.9.9"}`,
+		"node_modules/.package-lock.json":          `{"name":"bookkeeping","version":"1.0.0"}`,
+		"node_modules/.bin/something/package.json": `{"name":"binstub","version":"1.0.0"}`,
+	})
+}
+
+func TestInstalledNodeModules(t *testing.T) {
+	dir := installedTree(t)
+
+	deps, err := parseInstalledNodeModules(dir)
+	if err != nil {
+		t.Fatalf("parseInstalledNodeModules returned error: %v", err)
+	}
+
+	t.Run("reads the installed tree", func(t *testing.T) {
+		want := []string{"@babel/core", "accepts", "express", "jest", "mime-types", "ms", "ms"}
+		if got := depNames(deps); !reflect.DeepEqual(got, want) {
+			t.Errorf("parsed %v, want %v", got, want)
+		}
+	})
+
+	t.Run("only package roots count", func(t *testing.T) {
+		// A manifest inside a package is not an installed package. Counting one
+		// would invent a dependency that is not there, and inventing a
+		// dependency in a security report is worse than missing one: it sends
+		// somebody to fix nothing.
+		for _, d := range deps {
+			switch d.Name {
+			case "express-internal", "binstub", "bookkeeping":
+				t.Errorf("%s is not an installed package", d.Name)
+			}
+		}
+	})
+
+	t.Run("what package.json declares is direct", func(t *testing.T) {
+		for _, name := range []string{"express", "jest"} {
+			if d, _ := findDep(deps, name); !d.Direct {
+				t.Errorf("%s is declared and should be direct", name)
+			}
+		}
+		if d, _ := findDep(deps, "accepts"); d.Direct {
+			t.Error("accepts is hoisted, not declared")
+		}
+	})
+
+	t.Run("routes follow the directory layout", func(t *testing.T) {
+		if d, _ := findDep(deps, "accepts"); !reflect.DeepEqual(d.Path, []string{"express"}) {
+			t.Errorf("accepts route = %v, want [express]", d.Path)
+		}
+		if d, _ := findDep(deps, "mime-types"); !reflect.DeepEqual(d.Path, []string{"express", "accepts"}) {
+			t.Errorf("mime-types route = %v, want [express accepts]", d.Path)
+		}
+	})
+
+	t.Run("a nested copy shadows the hoisted one", func(t *testing.T) {
+		// express requires ms 2.0.0 and has its own copy; 2.1.3 sits hoisted
+		// for anything else. Both are installed and both must be reported, or
+		// an advisory against one version is checked against the other.
+		var nested, hoisted bool
+		for _, d := range deps {
+			if d.Name != "ms" {
+				continue
+			}
+			switch d.Version {
+			case "2.0.0":
+				nested = true
+				if !reflect.DeepEqual(d.Path, []string{"express"}) {
+					t.Errorf("nested ms route = %v, want [express]", d.Path)
+				}
+			case "2.1.3":
+				hoisted = true
+			}
+		}
+		if !nested || !hoisted {
+			t.Errorf("expected both installed copies of ms, nested=%v hoisted=%v", nested, hoisted)
+		}
+	})
+
+	t.Run("findings point at package.json, not at the build product", func(t *testing.T) {
+		// node_modules is not in the repository; package.json is the file a
+		// reader can open and act on.
+		want := filepath.Join(dir, "package.json")
+		for _, d := range deps {
+			if d.File != want {
+				t.Errorf("%s attributed to %q, want %q", d.Name, d.File, want)
+			}
+		}
+	})
+}
+
+// TestInstalledTreeIsLastResort pins the order of the sources. A lockfile is
+// the reproducible description of what will be installed; node_modules is one
+// machine's current state, which can be stale and is absent until somebody runs
+// an install.
+func TestInstalledTreeIsLastResort(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"package.json":      `{"dependencies":{"express":"^4.17.1"}}`,
+		"package-lock.json": lockV3,
+		// The installed tree disagrees with the lockfile: a stale install.
+		"node_modules/express/package.json": `{"name":"express","version":"3.0.0"}`,
+	})
+
+	deps, err := New(dir).collectDependencies()
+	if err != nil {
+		t.Fatalf("collectDependencies returned error: %v", err)
+	}
+
+	d, ok := findDep(deps, "express")
+	if !ok {
+		t.Fatal("express missing")
+	}
+	if d.Version != "4.17.1" {
+		t.Errorf("express version = %q, want the lockfile's 4.17.1", d.Version)
+	}
+	if _, ok := findDep(deps, "side-channel"); !ok {
+		t.Error("expected the lockfile tree, which contains side-channel")
+	}
+}
+
+// TestInstalledTreeReplacesTheManifest is the case the whole file exists for: a
+// repository that does not commit a lockfile. Reading package.json alone finds
+// one package; the installed tree finds what actually ships.
+func TestInstalledTreeReplacesTheManifest(t *testing.T) {
+	dir := installedTree(t)
+
+	deps, err := New(dir).collectDependencies()
+	if err != nil {
+		t.Fatalf("collectDependencies returned error: %v", err)
+	}
+
+	if len(deps) < 6 {
+		t.Fatalf("got %d dependencies, want the installed tree rather than the two declared", len(deps))
+	}
+
+	// The manifest's own entries must not be folded in on top: express would
+	// otherwise appear twice, once at "^4.17.1", which matches no advisory.
+	count := 0
+	for _, d := range deps {
+		if d.Name == "express" {
+			count++
+			if d.Version != "4.17.1" {
+				t.Errorf("express version = %q, want the installed 4.17.1", d.Version)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("express reported %d times, want once", count)
+	}
+}
+
+// TestInstalledKeyRejectsNonPackages covers the path check on its own, since it
+// is what stands between the walker and inventing dependencies out of manifests
+// that happen to live inside a package.
+func TestInstalledKeyRejectsNonPackages(t *testing.T) {
+	const project = "/repo"
+
+	tests := []struct {
+		dir  string
+		want string
+		ok   bool
+	}{
+		{"/repo/node_modules/express", "node_modules/express", true},
+		{"/repo/node_modules/@babel/core", "node_modules/@babel/core", true},
+		{"/repo/node_modules/express/node_modules/ms", "node_modules/express/node_modules/ms", true},
+		{"/repo/node_modules/express/lib", "", false},
+		{"/repo/node_modules/express/node_modules/ms/dist", "", false},
+		{"/repo", "", false},
+	}
+
+	for _, tt := range tests {
+		got, ok := installedKey(project, filepath.FromSlash(tt.dir))
+		if ok != tt.ok || got != tt.want {
+			t.Errorf("installedKey(%q) = (%q, %v), want (%q, %v)", tt.dir, got, ok, tt.want, tt.ok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A repository that does not commit a lockfile was scanned from `package.json`
alone — its declared dependencies, at ranges — so everything they pull in was
invisible. The scan succeeded, reported almost nothing, and the silence read as
safety. That is the worst shape a false negative can take in a security tool.

The answer was already on disk, and the scanner was stepping over it.
`node_modules` is in `DefaultIgnorePaths`, which is right for SAST and leak
detection where third-party code is noise, and wrong for the engine whose whole
subject is third-party code.

Measured on the yarn project from #58 with its lockfile deleted:

| | packages | vulnerabilities | SBOM components |
|---|---|---|---|
| `package.json` only (before) | 1 | 2 | 1 |
| `node_modules/` (this PR) | **52** | **12** | **52** |
| with the lockfile, for comparison | 52 | 12 | 52 |

Identical to what the lockfile produces.

## Related Issues

Third in the series after #57 and #58. **Merge after #58** — it builds on the
shared `walkGraph` introduced there.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New detection rule or secret pattern
- [x] Documentation
- [ ] Build, CI, or dependency change

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
- [x] `go build ./...` and `go test ./...` pass locally
- [x] `gofmt` and `golangci-lint run` are clean (0 issues)
- [x] I added or updated tests where appropriate
- [x] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
- [x] My changes do not introduce new `govulncheck` findings

## Notes for Reviewers

**Source order, and why.** `package-lock.json` → `yarn.lock` → `node_modules/`
→ `package.json`. A lockfile beats the installed tree because it describes what
*will* be installed, reproducibly; `node_modules` is one machine's current
state, which can be stale and does not exist until somebody runs an install.
There is a test with a deliberately stale install proving the lockfile wins.

**No network, deliberately.** Resolving ranges against a registry would answer a
different question — what would be installed *today*, not what is — and would
put a scan that currently runs inside an air-gapped network on the far side of
the internet. That is the wrong trade for this tool's positioning, so if it is
ever added it should be opt-in.

**Only package roots are taken.** A manifest can sit anywhere inside a package;
`node_modules/express/lib/package.json` is common, and `.bin` and
`.package-lock.json` are package-manager bookkeeping. Inventing a dependency in
a security report is worse than missing one — it sends somebody to fix something
that is not there. `installedKey` is tested on its own for this.

**`node_modules` stays ignored everywhere else.** The exception is scoped to the
SCA engine's own walk; SAST and leak detection still skip it, which is what
anyone would want.

**Cost.** Reading a few thousand small manifests is I/O bound and only happens
when no lockfile exists. There is a cap of 20 000 packages so a pathological
monorepo cannot turn a scan into an afternoon.

## Scope

npm only, again. The same "read what is actually installed" idea applies to
every ecosystem — `vendor/composer/installed.json` for PHP, `*.dist-info/
METADATA` in a virtualenv for Python — and those are separate PRs, as are the
lockfiles still unparsed (`pnpm-lock.yaml`, `poetry.lock`, `composer.lock`,
`Cargo.lock`).
