### PR TITLE
feat(sca): read composer.lock and vendor/composer/installed.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ like Grype, Trivy, and Dependency-Track.
 drogonsec scan . --format cyclonedx --output sbom.json
 ```
 
-> **Note:** the SBOM is a flat component inventory with Package URLs (purls). It
-> does not yet express the transitive dependency graph, because the SCA engine
-> resolves manifests rather than full lockfiles. Transitive resolution and SPDX
-> output are planned for a later release.
+> **Note:** the SBOM is a flat component inventory with Package URLs (purls).
+> Where a lockfile or an installed tree is available the inventory covers the
+> full transitive set, but the CycloneDX `dependencies` graph that records which
+> component pulled in which is not emitted yet. That and SPDX output are planned
+> for a later release.
 
 ---
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -85,7 +85,7 @@ The SCA engine scans your project's dependency manifest files for known CVEs, ou
 | **Go** | `go.mod` | Declared, including `// indirect` entries |
 | **Java** | `pom.xml` | Declared only |
 | **Ruby** | `Gemfile.lock` | Full tree |
-| **PHP** | `composer.json` | Declared only |
+| **PHP** | `composer.lock`, `vendor/composer/installed.json`, `composer.json` | Full tree |
 | **Dart** | `pubspec.yaml`, `pubspec.yml` | Declared only |
 
 **Depth is the column that matters.** A manifest states what a project asked
@@ -106,26 +106,36 @@ the YAML of Yarn 2 and later. Neither records which packages the project itself
 declared, so the sibling `package.json` supplies that; without one every package
 is still reported and only the direct/transitive split is lost.
 
-For npm the engine falls back through three sources, in this order:
+For npm and PHP the engine falls back through three sources, in this order:
 
-1. **A lockfile** — `package-lock.json`, then `yarn.lock`. What *will* be
-   installed, reproducibly.
-2. **`node_modules/` on disk** — what *is* installed. Read only when no lockfile
-   covers the project, which makes a repository that does not commit one
-   scannable in full: a CI job that runs `npm ci` before the scan, or any
-   working copy after an install. Each installed package carries its own
-   manifest with a resolved version, and the directory layout is the resolution.
-3. **`package.json`** — the declared dependencies, at ranges. The last resort,
-   and the only one that leaves the transitive tree unseen.
+1. **A lockfile** — `package-lock.json`, then `yarn.lock`; `composer.lock` for
+   PHP. What *will* be installed, reproducibly.
+2. **The installed tree on disk** — what *is* installed. Read only when no
+   lockfile covers the project, which makes a repository that does not commit
+   one scannable in full: a CI job that runs `npm ci` or `composer install`
+   before the scan, or any working copy after an install. For npm that means
+   `node_modules/`, where each package carries its own manifest and the
+   directory layout is the resolution; for PHP it means
+   `vendor/composer/installed.json`, in which Composer records the whole
+   resolved graph in one file, in either the Composer 1 or the Composer 2 shape.
+3. **The manifest** — `package.json` or `composer.json`, the declared
+   dependencies at ranges. The last resort, and the only one that leaves the
+   transitive tree unseen.
 
 None of the three touches the network. Resolving ranges against a registry would
 answer a different question — what would be installed today — and would put a
 scan that currently runs air-gapped on the far side of the internet.
 
+Composer resolves one version of a package for the whole project, so a
+`composer.lock` gives the full tree with no ambiguity to resolve. What it does
+not record is which packages the project itself asked for; the sibling
+`composer.json` supplies that, and without one every package is still reported
+and only the direct/transitive split is lost. Platform requirements — `php`,
+`ext-json`, `composer-runtime-api` — are not packages and are never reported.
+
 Not yet parsed, so a project relying on one of these is **not** covered by the
 ecosystem's row above: `pnpm-lock.yaml`, `poetry.lock`, `Pipfile.lock`,
-`composer.lock`, `Cargo.lock`, `go.sum`, Gradle builds, and the .NET ecosystem
-entirely.
+`Cargo.lock`, `go.sum`, Gradle builds, and the .NET ecosystem entirely.
 
 ### What the SCA Engine Reports
 

--- a/internal/sca/composer_test.go
+++ b/internal/sca/composer_test.go
@@ -1,0 +1,366 @@
+package sca
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// The fixtures under testdata/composer were produced by Composer 2 itself, from
+// the composer.json committed beside them:
+//
+//	docker run --rm composer:2 install --ignore-platform-reqs --no-scripts
+//
+// Only the fields no parser reads — dist hashes, autoload maps, author blocks —
+// were stripped afterwards, and guzzlehttp/guzzle was left whole so the tests
+// keep exercising a real entry's worth of noise. Regenerate them the same way
+// rather than editing them by hand: every quirk worth testing here, from the
+// "v" that Symfony tags its releases with to the platform requirements mixed
+// into every require block, is something the tool does and nobody would think
+// to invent.
+//
+// The project declares three packages and installs twenty.
+const composerFixture = "testdata/composer"
+
+// composerAllPackages is the full installed set, as both composer.lock and
+// installed.json record it.
+var composerAllPackages = []string{
+	"guzzlehttp/guzzle",
+	"guzzlehttp/promises",
+	"guzzlehttp/psr7",
+	"monolog/monolog",
+	"psr/event-dispatcher",
+	"psr/http-message",
+	"psr/log",
+	"ralouphie/getallheaders",
+	"symfony/deprecation-contracts",
+	"symfony/error-handler",
+	"symfony/event-dispatcher",
+	"symfony/event-dispatcher-contracts",
+	"symfony/http-foundation",
+	"symfony/http-kernel",
+	"symfony/polyfill-ctype",
+	"symfony/polyfill-mbstring",
+	"symfony/polyfill-php73",
+	"symfony/polyfill-php80",
+	"symfony/polyfill-php83",
+	"symfony/var-dumper",
+}
+
+func TestComposerLock(t *testing.T) {
+	deps, err := (&ComposerLockParser{}).Parse(filepath.Join(composerFixture, "composer.lock"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	t.Run("reports the whole tree, not the three declared packages", func(t *testing.T) {
+		if got := depNames(deps); !reflect.DeepEqual(got, composerAllPackages) {
+			t.Errorf("parsed %v, want %v", got, composerAllPackages)
+		}
+	})
+
+	t.Run("development packages are installed code too", func(t *testing.T) {
+		// monolog arrives through "packages-dev", which composer installs into
+		// the same vendor directory as everything else. A vulnerability there
+		// runs in CI, and in any developer's working copy.
+		d, ok := findDep(deps, "monolog/monolog")
+		if !ok {
+			t.Fatal("monolog/monolog missing: packages-dev was not read")
+		}
+		if !d.Direct {
+			t.Error("monolog/monolog is declared in require-dev and is therefore direct")
+		}
+	})
+
+	t.Run("only what composer.json requires is direct", func(t *testing.T) {
+		direct := map[string]bool{
+			"guzzlehttp/guzzle":   true,
+			"symfony/http-kernel": true,
+			"monolog/monolog":     true,
+		}
+		for _, d := range deps {
+			if d.Direct != direct[d.Name] {
+				t.Errorf("%s direct = %v, want %v", d.Name, d.Direct, direct[d.Name])
+			}
+		}
+	})
+
+	t.Run("the route records how a package was introduced", func(t *testing.T) {
+		tests := []struct {
+			name string
+			want []string
+		}{
+			{"guzzlehttp/guzzle", nil},
+			{"guzzlehttp/psr7", []string{"guzzlehttp/guzzle"}},
+			{"psr/http-message", []string{"guzzlehttp/guzzle", "guzzlehttp/psr7"}},
+			// Three hops down, and reachable no other way. This is the package
+			// a manifest-only scan never sees and nobody can place by hand.
+			{"psr/event-dispatcher", []string{
+				"symfony/http-kernel",
+				"symfony/event-dispatcher",
+				"symfony/event-dispatcher-contracts",
+			}},
+			// psr/log is required by both monolog and symfony/http-kernel. The
+			// shortest route wins, and monolog is queued first among the roots.
+			{"psr/log", []string{"monolog/monolog"}},
+		}
+		for _, tt := range tests {
+			d, ok := findDep(deps, tt.name)
+			if !ok {
+				t.Fatalf("%s missing", tt.name)
+			}
+			if !reflect.DeepEqual(d.Path, tt.want) {
+				t.Errorf("%s route = %v, want %v", tt.name, d.Path, tt.want)
+			}
+		}
+	})
+
+	t.Run("versions are kept as the lockfile writes them", func(t *testing.T) {
+		// Symfony tags its releases "v6.4.43". OSV normalises the prefix away
+		// before matching, so rewriting it here would only make the reported
+		// version differ from the one a developer greps the lockfile for.
+		d, _ := findDep(deps, "symfony/http-kernel")
+		if d.Version != "v5.4.0" {
+			t.Errorf("symfony/http-kernel version = %q, want v5.4.0", d.Version)
+		}
+	})
+
+	t.Run("platform requirements are not packages", func(t *testing.T) {
+		// Every require block in this fixture mixes php and ext-* entries in
+		// with the real dependencies. They describe the interpreter, cannot be
+		// looked up in an advisory database, and would inflate the count.
+		for _, d := range deps {
+			if !isPackagistName(d.Name) {
+				t.Errorf("%q is a platform requirement, not a Packagist package", d.Name)
+			}
+		}
+	})
+
+	t.Run("findings point at the lockfile", func(t *testing.T) {
+		want := filepath.Join(composerFixture, "composer.lock")
+		for _, d := range deps {
+			if d.File != want {
+				t.Errorf("%s attributed to %q, want %q", d.Name, d.File, want)
+			}
+			if d.Ecosystem != "packagist" {
+				t.Errorf("%s ecosystem = %q, want packagist", d.Name, d.Ecosystem)
+			}
+		}
+	})
+}
+
+// TestComposerLockWithoutManifest covers a lockfile committed on its own, or
+// one reached without its sibling. composer.lock does not record what the root
+// project asked for, so the split is lost — but the tree is not, and every
+// installed package still has to be reported.
+func TestComposerLockWithoutManifest(t *testing.T) {
+	lock, err := os.ReadFile(filepath.Join(composerFixture, "composer.lock"))
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	dir := writeFiles(t, map[string]string{"composer.lock": string(lock)})
+
+	deps, err := (&ComposerLockParser{}).Parse(filepath.Join(dir, "composer.lock"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	if got := depNames(deps); !reflect.DeepEqual(got, composerAllPackages) {
+		t.Errorf("parsed %v, want the full tree %v", got, composerAllPackages)
+	}
+	for _, d := range deps {
+		if d.Direct {
+			t.Errorf("%s cannot be known to be direct without composer.json", d.Name)
+		}
+		if len(d.Path) != 0 {
+			t.Errorf("%s has route %v, but the walk has no root to start from", d.Name, d.Path)
+		}
+	}
+}
+
+// TestComposerLockResolvesEdgesCaseInsensitively guards the one thing a name
+// key can get wrong. Composer matches package names case-insensitively, so a
+// require block that spells a dependency "Monolog/Monolog" installs the same
+// package as "monolog/monolog" — and an edge written that way still has to find
+// its node, or the package it introduces is reported with no route.
+func TestComposerLockResolvesEdgesCaseInsensitively(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"composer.json": `{"require":{"Acme/App":"^1.0"}}`,
+		"composer.lock": `{
+		  "packages": [
+		    {"name":"acme/app","version":"1.0.0","require":{"php":">=7.2","Monolog/Monolog":"^1.25"}},
+		    {"name":"monolog/monolog","version":"1.25.0"}
+		  ],
+		  "packages-dev": []
+		}`,
+	})
+
+	deps, err := (&ComposerLockParser{}).Parse(filepath.Join(dir, "composer.lock"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	app, ok := findDep(deps, "acme/app")
+	if !ok {
+		t.Fatal("acme/app missing")
+	}
+	if !app.Direct {
+		t.Error(`acme/app is required as "Acme/App" and is still the declared package`)
+	}
+
+	monolog, ok := findDep(deps, "monolog/monolog")
+	if !ok {
+		t.Fatal("monolog/monolog missing")
+	}
+	if want := []string{"acme/app"}; !reflect.DeepEqual(monolog.Path, want) {
+		t.Errorf("monolog route = %v, want %v", monolog.Path, want)
+	}
+}
+
+func TestComposerLockRejectsMalformedJSON(t *testing.T) {
+	dir := writeFiles(t, map[string]string{"composer.lock": `{"packages": [`})
+
+	if _, err := (&ComposerLockParser{}).Parse(filepath.Join(dir, "composer.lock")); err == nil {
+		t.Error("Parse accepted a truncated lockfile")
+	}
+}
+
+func TestInstalledComposer(t *testing.T) {
+	deps, err := parseInstalledComposer(composerFixture)
+	if err != nil {
+		t.Fatalf("parseInstalledComposer returned error: %v", err)
+	}
+
+	t.Run("reads the same tree the lockfile describes", func(t *testing.T) {
+		if got := depNames(deps); !reflect.DeepEqual(got, composerAllPackages) {
+			t.Errorf("parsed %v, want %v", got, composerAllPackages)
+		}
+	})
+
+	t.Run("routes survive the change of source", func(t *testing.T) {
+		d, ok := findDep(deps, "psr/event-dispatcher")
+		if !ok {
+			t.Fatal("psr/event-dispatcher missing")
+		}
+		want := []string{
+			"symfony/http-kernel",
+			"symfony/event-dispatcher",
+			"symfony/event-dispatcher-contracts",
+		}
+		if !reflect.DeepEqual(d.Path, want) {
+			t.Errorf("route = %v, want %v", d.Path, want)
+		}
+	})
+
+	t.Run("findings point at composer.json, not at vendor", func(t *testing.T) {
+		// vendor/ is a build product and is usually not in the repository.
+		// composer.json is the file a reader can open.
+		want := filepath.Join(composerFixture, "composer.json")
+		for _, d := range deps {
+			if d.File != want {
+				t.Errorf("%s attributed to %q, want %q", d.Name, d.File, want)
+			}
+		}
+	})
+}
+
+// TestInstalledComposerV1 covers the other envelope. Composer 1 wrote
+// installed.json as a bare array; Composer 2 wraps the same entries in an
+// object that also names the development packages. A repository last installed
+// with Composer 1 is exactly the kind that has no lockfile committed, so the
+// older shape is the one this tier is most likely to meet.
+func TestInstalledComposerV1(t *testing.T) {
+	deps, err := parseInstalledComposer("testdata/composer1")
+	if err != nil {
+		t.Fatalf("parseInstalledComposer returned error: %v", err)
+	}
+
+	if got := depNames(deps); !reflect.DeepEqual(got, composerAllPackages) {
+		t.Errorf("parsed %v, want %v", got, composerAllPackages)
+	}
+}
+
+func TestInstalledComposerWithoutVendor(t *testing.T) {
+	dir := writeFiles(t, map[string]string{"composer.json": `{"require":{"acme/app":"^1.0"}}`})
+
+	deps, err := parseInstalledComposer(dir)
+	if err == nil {
+		t.Error("a missing vendor/composer/installed.json should be reported as an error")
+	}
+	if len(deps) != 0 {
+		t.Errorf("returned %d dependencies with nothing installed", len(deps))
+	}
+}
+
+// TestComposerLockTakesPrecedenceOverManifest pins the tier order for PHP. Both
+// sources describe the same project, so merging them would report guzzle twice
+// — once at 6.5.0 and once at the range composer.json asked for, which is not a
+// version and matches no advisory.
+func TestComposerLockTakesPrecedenceOverManifest(t *testing.T) {
+	e := New(composerFixture)
+
+	deps, err := e.collectDependencies()
+	if err != nil {
+		t.Fatalf("collectDependencies returned error: %v", err)
+	}
+
+	var packagist []Dependency
+	for _, d := range deps {
+		if d.Ecosystem == "packagist" {
+			packagist = append(packagist, d)
+		}
+	}
+
+	if len(packagist) != len(composerAllPackages) {
+		t.Errorf("collected %d packagist dependencies, want %d — the manifest and the lockfile were both counted",
+			len(packagist), len(composerAllPackages))
+	}
+	for _, d := range packagist {
+		if filepath.Base(d.File) != "composer.lock" {
+			t.Errorf("%s came from %s, but the lockfile covers this directory", d.Name, filepath.Base(d.File))
+		}
+	}
+}
+
+// TestInstalledComposerIsLastResort checks the tier below: with the lockfile
+// gone, vendor/ still describes the full tree, and only with vendor/ gone as
+// well does the scan fall back to the three declared names.
+func TestInstalledComposerIsLastResort(t *testing.T) {
+	installed, err := os.ReadFile(filepath.Join(composerFixture, "vendor", "composer", "installed.json"))
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	manifest, err := os.ReadFile(filepath.Join(composerFixture, "composer.json"))
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+
+	dir := writeFiles(t, map[string]string{
+		"composer.json":                  string(manifest),
+		"vendor/composer/installed.json": string(installed),
+	})
+
+	deps, err := New(dir).collectDependencies()
+	if err != nil {
+		t.Fatalf("collectDependencies returned error: %v", err)
+	}
+	if got := depNames(deps); !reflect.DeepEqual(got, composerAllPackages) {
+		t.Errorf("with no lockfile the installed tree should be read, got %v", got)
+	}
+
+	if err := os.RemoveAll(filepath.Join(dir, "vendor")); err != nil {
+		t.Fatalf("removing vendor: %v", err)
+	}
+
+	deps, err = New(dir).collectDependencies()
+	if err != nil {
+		t.Fatalf("collectDependencies returned error: %v", err)
+	}
+	// What is left is composer.json: the two real packages it names, at ranges,
+	// with php and ext-json dropped as platform requirements.
+	want := []string{"guzzlehttp/guzzle", "monolog/monolog", "symfony/http-kernel"}
+	if got := depNames(deps); !reflect.DeepEqual(got, want) {
+		t.Errorf("manifest fallback parsed %v, want %v", got, want)
+	}
+}

--- a/internal/sca/engine.go
+++ b/internal/sca/engine.go
@@ -86,6 +86,7 @@ func (e *Engine) registerParsers() {
 	e.parsers = []ManifestParser{
 		&PackageLockParser{},
 		&YarnLockParser{},
+		&ComposerLockParser{},
 		&PackageJSONParser{},
 		&PomXMLParser{},
 		&RequirementsTXTParser{},
@@ -244,19 +245,21 @@ func (e *Engine) collectDependencies() ([]Dependency, error) {
 	// Second source of truth, for projects that do not commit a lockfile: the
 	// tree already installed on disk. It is read only where no lockfile spoke,
 	// because a lockfile describes what will be installed reproducibly, while
-	// node_modules describes one machine's current state — which may be stale,
-	// and is absent altogether until somebody runs an install.
-	for _, dir := range npmProjectDirs(manifestDeps) {
-		key := lockKey(filepath.Join(dir, "package.json"), "npm")
-		if locked[key] {
-			continue
+	// an installed tree describes one machine's current state — which may be
+	// stale, and is absent altogether until somebody runs an install.
+	for _, source := range installedSources {
+		for _, dir := range projectDirs(manifestDeps, source.ecosystem) {
+			key := lockKey(filepath.Join(dir, source.manifest), source.ecosystem)
+			if locked[key] {
+				continue
+			}
+			installed, err := source.parse(dir)
+			if err != nil || len(installed) == 0 {
+				continue
+			}
+			locked[key] = true
+			lockfileDeps = append(lockfileDeps, installed...)
 		}
-		installed, err := parseInstalledNodeModules(dir)
-		if err != nil || len(installed) == 0 {
-			continue
-		}
-		locked[key] = true
-		lockfileDeps = append(lockfileDeps, installed...)
 	}
 
 	for _, dep := range manifestDeps {
@@ -267,6 +270,20 @@ func (e *Engine) collectDependencies() ([]Dependency, error) {
 	}
 
 	return lockfileDeps, nil
+}
+
+// installedSource is a reader for one ecosystem's installed tree: the
+// directory it is rooted at is a project directory, and the findings are
+// attributed to the named manifest rather than to the build product itself.
+type installedSource struct {
+	ecosystem string
+	manifest  string
+	parse     func(projectDir string) ([]Dependency, error)
+}
+
+var installedSources = []installedSource{
+	{ecosystem: "npm", manifest: "package.json", parse: parseInstalledNodeModules},
+	{ecosystem: "packagist", manifest: "composer.json", parse: parseInstalledComposer},
 }
 
 // lockKey identifies an ecosystem within one project directory.
@@ -671,7 +688,11 @@ func (p *ComposerParser) Parse(path string) ([]Dependency, error) {
 	var deps []Dependency
 	addDeps := func(m map[string]string) {
 		for name, version := range m {
-			if name == "php" {
+			// Platform requirements — php itself, ext-json, lib-openssl,
+			// composer-runtime-api — describe the interpreter rather than code
+			// fetched from a registry. Reported as packages they inflate the
+			// dependency count with names no advisory database holds.
+			if !isPackagistName(name) {
 				continue
 			}
 			deps = append(deps, Dependency{

--- a/internal/sca/installed.go
+++ b/internal/sca/installed.go
@@ -1,6 +1,7 @@
 package sca
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/fs"
 	"path/filepath"
@@ -135,13 +136,67 @@ func installedKey(projectDir, packageDir string) (string, bool) {
 	return "", false
 }
 
-// npmProjectDirs lists, in a stable order, the directories holding an npm
-// manifest.
-func npmProjectDirs(deps []Dependency) []string {
+// parseInstalledComposer reads the dependency tree from vendor/composer/
+// installed.json.
+//
+// Composer writes this file on every install, and it is the exact record of
+// what landed in vendor/: a resolved version for every package, and each
+// package's own require block. Where node_modules has to be walked and its
+// layout interpreted, PHP hands over the whole graph in one file — the same
+// shape composer.lock carries, so the same parsing serves both.
+//
+// It is read only for a project that does not commit its lockfile. That is
+// common enough in PHP to matter: composer.lock is gitignored in plenty of
+// library repositories, where committing it is in fact the documented advice,
+// and without this such a project is scanned from composer.json alone — a
+// handful of names at ranges, with the tree they pull in unseen.
+func parseInstalledComposer(projectDir string) ([]Dependency, error) {
+	path := filepath.Join(projectDir, "vendor", "composer", "installed.json")
+
+	data, err := readManifestFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Composer 2 wraps the list in an object that also names the development
+	// packages; Composer 1 writes the bare array. The first meaningful
+	// character tells them apart, which is steadier than unmarshalling twice
+	// and reading the failure as a format signal.
+	var packages []composerPackage
+	if bytes.HasPrefix(bytes.TrimLeft(data, " \t\r\n"), []byte("[")) {
+		if err := json.Unmarshal(data, &packages); err != nil {
+			return nil, err
+		}
+	} else {
+		var installed struct {
+			Packages []composerPackage `json:"packages"`
+		}
+		if err := json.Unmarshal(data, &installed); err != nil {
+			return nil, err
+		}
+		packages = installed.Packages
+	}
+
+	nodes := composerNodes(packages)
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+
+	// The findings are attributed to composer.json: it is the file in the
+	// repository, while vendor/ is a build product that is usually not.
+	manifest := filepath.Join(projectDir, "composer.json")
+	roots := declaredInComposerJSON(manifest)
+
+	return walkGraph(nodes, roots, composerResolver(nodes), "packagist", manifest), nil
+}
+
+// projectDirs lists, in a stable order, the directories holding a manifest of
+// one ecosystem.
+func projectDirs(deps []Dependency, ecosystem string) []string {
 	seen := make(map[string]bool)
 	var dirs []string
 	for _, dep := range deps {
-		if dep.Ecosystem != "npm" {
+		if dep.Ecosystem != ecosystem {
 			continue
 		}
 		dir := filepath.Dir(dep.File)

--- a/internal/sca/lockfiles.go
+++ b/internal/sca/lockfiles.go
@@ -565,6 +565,160 @@ func unquoteYarn(s string) string {
 	return strings.Trim(strings.TrimSpace(s), `"'`)
 }
 
+// ============= composer =============
+
+// ComposerLockParser parses PHP's composer.lock.
+//
+// Composer resolves to one version of a package for the whole project — there
+// is no equivalent of a nested node_modules copy — so a package name is on its
+// own a unique key, and an edge resolves by name alone. The constraint the
+// dependent wrote is not consulted: the lockfile has already decided which
+// version satisfies it, and there is only ever the one.
+//
+// Like yarn.lock, composer.lock does not record what the root project asked
+// for: "packages" and "packages-dev" are flat lists in which a declared
+// dependency looks exactly like something six levels down. The sibling
+// composer.json supplies that, and without one every package is still reported
+// with only the direct/transitive split lost.
+type ComposerLockParser struct{}
+
+func (p *ComposerLockParser) Name() string    { return "composer (lockfile)" }
+func (p *ComposerLockParser) Files() []string { return []string{"composer.lock"} }
+func (p *ComposerLockParser) Lockfile()       {}
+
+// composerLock covers the parts of composer.lock this parser reads. Development
+// dependencies live in their own list but are installed into the same flat
+// vendor directory, so both are read into one graph.
+type composerLock struct {
+	Packages    []composerPackage `json:"packages"`
+	PackagesDev []composerPackage `json:"packages-dev"`
+}
+
+// composerPackage is one entry of either list. The same shape appears in
+// vendor/composer/installed.json, which is why both sources share it.
+type composerPackage struct {
+	Name    string            `json:"name"`
+	Version string            `json:"version"`
+	Require map[string]string `json:"require"`
+}
+
+func (p *ComposerLockParser) Parse(path string) ([]Dependency, error) {
+	data, err := readManifestFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lock composerLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return nil, err
+	}
+
+	nodes := composerNodes(lock.Packages, lock.PackagesDev)
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+
+	roots := declaredInComposerJSON(filepath.Join(filepath.Dir(path), "composer.json"))
+	return walkGraph(nodes, roots, composerResolver(nodes), "packagist", path), nil
+}
+
+// composerNodes reduces the lists composer writes into the node map the graph
+// walk expects, keyed by package name.
+func composerNodes(lists ...[]composerPackage) map[string]node {
+	nodes := make(map[string]node)
+
+	for _, list := range lists {
+		for _, pkg := range list {
+			if pkg.Name == "" || pkg.Version == "" {
+				continue
+			}
+
+			deps := make(map[string]string, len(pkg.Require))
+			for name, constraint := range pkg.Require {
+				if !isPackagistName(name) {
+					continue
+				}
+				deps[composerKey(name)] = constraint
+			}
+
+			// The version is kept exactly as the lockfile writes it, "v" and
+			// all — that is the string a developer will find when they grep the
+			// file, and OSV normalises the prefix away before matching.
+			nodes[composerKey(pkg.Name)] = node{name: pkg.Name, version: pkg.Version, deps: deps}
+		}
+	}
+
+	return nodes
+}
+
+// composerResolver answers a dependency edge by name, which is all Composer's
+// flat installation leaves to do.
+//
+// An edge that names nothing installed is left unresolved, and the two ways
+// that happens are both harmless here. A virtual package — "psr/http-message-
+// implementation", which guzzlehttp/psr7 provides rather than being — has no
+// entry because no such thing is installed. A replaced package, as when
+// symfony/symfony stands in for symfony/http-kernel, has none for the same
+// reason. Neither loses a package from the report: everything installed is
+// listed regardless, and what is lost at most is one route through the graph.
+func composerResolver(nodes map[string]node) resolver {
+	return func(_, name, _ string) (string, bool) {
+		key := composerKey(name)
+		_, ok := nodes[key]
+		return key, ok
+	}
+}
+
+// declaredInComposerJSON reads what the project requires of itself, as name to
+// constraint. A missing or unreadable composer.json is not an error: the
+// resolved graph is still complete, and only the direct/transitive split is
+// lost.
+func declaredInComposerJSON(path string) map[string]string {
+	data, err := readManifestFile(path)
+	if err != nil {
+		return nil
+	}
+	var pkg struct {
+		Require    map[string]string `json:"require"`
+		RequireDev map[string]string `json:"require-dev"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+
+	roots := make(map[string]string)
+	for _, m := range []map[string]string{pkg.Require, pkg.RequireDev} {
+		for name, constraint := range m {
+			if !isPackagistName(name) {
+				continue
+			}
+			roots[composerKey(name)] = constraint
+		}
+	}
+	return roots
+}
+
+// isPackagistName separates real packages from Composer's platform packages.
+//
+// A require block mixes the two freely: "php": ">=7.2", "ext-json": "*" and
+// "composer-runtime-api": "^2.0" sit alongside "guzzlehttp/psr7": "^1.6". The
+// platform entries describe the interpreter and its extensions, not code
+// fetched from a registry, and querying an advisory database for a package
+// named "php" or "ext-json" returns nothing while making the dependency count
+// wrong. Every Packagist package is published as vendor/name, and no platform
+// package contains a slash, so the slash is the whole test.
+func isPackagistName(name string) bool {
+	return strings.Contains(name, "/")
+}
+
+// composerKey normalises a package name for lookup. Composer treats names
+// case-insensitively — a require block spelling "Monolog/Monolog" installs the
+// same package as "monolog/monolog" — so an edge written in either case has to
+// find the one node.
+func composerKey(name string) string {
+	return strings.ToLower(name)
+}
+
 // npmNameFromKey recovers a package name from its installation path. Splitting
 // on the last "node_modules/" keeps scoped names intact: the "/" inside
 // "@scope/pkg" is not a path separator here.

--- a/internal/sca/testdata/composer/composer.json
+++ b/internal/sca/testdata/composer/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "drogonsec/fixture",
+  "version": "1.0.0",
+  "require": {
+    "php": ">=7.2",
+    "ext-json": "*",
+    "guzzlehttp/guzzle": "6.5.0",
+    "symfony/http-kernel": "5.4.0"
+  },
+  "require-dev": { "monolog/monolog": "1.25.0" }
+}

--- a/internal/sca/testdata/composer/composer.lock
+++ b/internal/sca/testdata/composer/composer.lock
@@ -1,0 +1,265 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state"
+    ],
+    "content-hash": "84a4db141dffa6a0dae5fc7908dc5d6a",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "dbc2bc3a293ed6b1ae08a3651e2bfd213d19b6a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/dbc2bc3a293ed6b1ae08a3651e2bfd213d19b6a5",
+                "reference": "dbc2bc3a293ed6b1ae08a3651e2bfd213d19b6a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/master"
+            },
+            "time": "2019-12-07T18:20:45+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.5.3",
+            "require": {
+                "php": ">=5.5"
+            },
+            "type": "library"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.9.1",
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "type": "library"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.1",
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v6.3.12",
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v6.4.43",
+            "require": {
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.7.1",
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v6.4.43",
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php83": "^1.27"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v5.4.0",
+            "require": {
+                "php": ">=7.2.5",
+                "psr/log": "^1|^2",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^5.0|^6.0",
+                "symfony/http-foundation": "^5.3.7|^6.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.37.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.41.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v6.4.43",
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "type": "library"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "monolog/monolog",
+            "version": "1.25.0",
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "type": "library"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.2",
+        "ext-json": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/internal/sca/testdata/composer/vendor/composer/installed.json
+++ b/internal/sca/testdata/composer/vendor/composer/installed.json
@@ -1,0 +1,232 @@
+{
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.5.0",
+            "version_normalized": "6.5.0.0",
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": ">=5.5"
+            },
+            "type": "library",
+            "install-path": "../guzzlehttp/guzzle"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.5.3",
+            "version_normalized": "1.5.3.0",
+            "require": {
+                "php": ">=5.5"
+            },
+            "type": "library",
+            "install-path": "../guzzlehttp/promises"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.9.1",
+            "version_normalized": "1.9.1.0",
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "type": "library",
+            "install-path": "../guzzlehttp/psr7"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.25.0",
+            "version_normalized": "1.25.0.0",
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "type": "library",
+            "install-path": "../monolog/monolog"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "version_normalized": "1.0.0.0",
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "install-path": "../psr/event-dispatcher"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.1",
+            "version_normalized": "1.1.0.0",
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "install-path": "../psr/http-message"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "version_normalized": "1.1.4.0",
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "install-path": "../psr/log"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "version_normalized": "3.0.3.0",
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "install-path": "../ralouphie/getallheaders"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "version_normalized": "3.7.1.0",
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "install-path": "../symfony/deprecation-contracts"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v6.3.12",
+            "version_normalized": "6.3.12.0",
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "type": "library",
+            "install-path": "../symfony/error-handler"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v6.4.43",
+            "version_normalized": "6.4.43.0",
+            "require": {
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "install-path": "../symfony/event-dispatcher"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.7.1",
+            "version_normalized": "3.7.1.0",
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "install-path": "../symfony/event-dispatcher-contracts"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v6.4.43",
+            "version_normalized": "6.4.43.0",
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php83": "^1.27"
+            },
+            "type": "library",
+            "install-path": "../symfony/http-foundation"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v5.4.0",
+            "version_normalized": "5.4.0.0",
+            "require": {
+                "php": ">=7.2.5",
+                "psr/log": "^1|^2",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^5.0|^6.0",
+                "symfony/http-foundation": "^5.3.7|^6.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "install-path": "../symfony/http-kernel"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "version_normalized": "1.37.0.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "install-path": "../symfony/polyfill-ctype"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "version_normalized": "1.38.2.0",
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "install-path": "../symfony/polyfill-mbstring"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.37.0",
+            "version_normalized": "1.37.0.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "install-path": "../symfony/polyfill-php73"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "version_normalized": "1.37.0.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "install-path": "../symfony/polyfill-php80"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.41.0",
+            "version_normalized": "1.41.0.0",
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "install-path": "../symfony/polyfill-php83"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v6.4.43",
+            "version_normalized": "6.4.43.0",
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "type": "library",
+            "install-path": "../symfony/var-dumper"
+        }
+    ],
+    "dev": true,
+    "dev-package-names": [
+        "monolog/monolog"
+    ]
+}

--- a/internal/sca/testdata/composer1/composer.json
+++ b/internal/sca/testdata/composer1/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "drogonsec/fixture",
+  "version": "1.0.0",
+  "require": {
+    "php": ">=7.2",
+    "ext-json": "*",
+    "guzzlehttp/guzzle": "6.5.0",
+    "symfony/http-kernel": "5.4.0"
+  },
+  "require-dev": { "monolog/monolog": "1.25.0" }
+}

--- a/internal/sca/testdata/composer1/vendor/composer/installed.json
+++ b/internal/sca/testdata/composer1/vendor/composer/installed.json
@@ -1,0 +1,226 @@
+[
+    {
+        "name": "guzzlehttp/guzzle",
+        "version": "6.5.0",
+        "version_normalized": "6.5.0.0",
+        "require": {
+            "ext-json": "*",
+            "guzzlehttp/promises": "^1.0",
+            "guzzlehttp/psr7": "^1.6.1",
+            "php": ">=5.5"
+        },
+        "type": "library",
+        "install-path": "../guzzlehttp/guzzle"
+    },
+    {
+        "name": "guzzlehttp/promises",
+        "version": "1.5.3",
+        "version_normalized": "1.5.3.0",
+        "require": {
+            "php": ">=5.5"
+        },
+        "type": "library",
+        "install-path": "../guzzlehttp/promises"
+    },
+    {
+        "name": "guzzlehttp/psr7",
+        "version": "1.9.1",
+        "version_normalized": "1.9.1.0",
+        "require": {
+            "php": ">=5.4.0",
+            "psr/http-message": "~1.0",
+            "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+        },
+        "type": "library",
+        "install-path": "../guzzlehttp/psr7"
+    },
+    {
+        "name": "monolog/monolog",
+        "version": "1.25.0",
+        "version_normalized": "1.25.0.0",
+        "require": {
+            "php": ">=5.3.0",
+            "psr/log": "~1.0"
+        },
+        "type": "library",
+        "install-path": "../monolog/monolog"
+    },
+    {
+        "name": "psr/event-dispatcher",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "require": {
+            "php": ">=7.2.0"
+        },
+        "type": "library",
+        "install-path": "../psr/event-dispatcher"
+    },
+    {
+        "name": "psr/http-message",
+        "version": "1.1",
+        "version_normalized": "1.1.0.0",
+        "require": {
+            "php": "^7.2 || ^8.0"
+        },
+        "type": "library",
+        "install-path": "../psr/http-message"
+    },
+    {
+        "name": "psr/log",
+        "version": "1.1.4",
+        "version_normalized": "1.1.4.0",
+        "require": {
+            "php": ">=5.3.0"
+        },
+        "type": "library",
+        "install-path": "../psr/log"
+    },
+    {
+        "name": "ralouphie/getallheaders",
+        "version": "3.0.3",
+        "version_normalized": "3.0.3.0",
+        "require": {
+            "php": ">=5.6"
+        },
+        "type": "library",
+        "install-path": "../ralouphie/getallheaders"
+    },
+    {
+        "name": "symfony/deprecation-contracts",
+        "version": "v3.7.1",
+        "version_normalized": "3.7.1.0",
+        "require": {
+            "php": ">=8.1"
+        },
+        "type": "library",
+        "install-path": "../symfony/deprecation-contracts"
+    },
+    {
+        "name": "symfony/error-handler",
+        "version": "v6.3.12",
+        "version_normalized": "6.3.12.0",
+        "require": {
+            "php": ">=8.1",
+            "psr/log": "^1|^2|^3",
+            "symfony/var-dumper": "^5.4|^6.0"
+        },
+        "type": "library",
+        "install-path": "../symfony/error-handler"
+    },
+    {
+        "name": "symfony/event-dispatcher",
+        "version": "v6.4.43",
+        "version_normalized": "6.4.43.0",
+        "require": {
+            "php": ">=8.1",
+            "symfony/event-dispatcher-contracts": "^2.5|^3"
+        },
+        "type": "library",
+        "install-path": "../symfony/event-dispatcher"
+    },
+    {
+        "name": "symfony/event-dispatcher-contracts",
+        "version": "v3.7.1",
+        "version_normalized": "3.7.1.0",
+        "require": {
+            "php": ">=8.1",
+            "psr/event-dispatcher": "^1"
+        },
+        "type": "library",
+        "install-path": "../symfony/event-dispatcher-contracts"
+    },
+    {
+        "name": "symfony/http-foundation",
+        "version": "v6.4.43",
+        "version_normalized": "6.4.43.0",
+        "require": {
+            "php": ">=8.1",
+            "symfony/deprecation-contracts": "^2.5|^3",
+            "symfony/polyfill-mbstring": "~1.1",
+            "symfony/polyfill-php83": "^1.27"
+        },
+        "type": "library",
+        "install-path": "../symfony/http-foundation"
+    },
+    {
+        "name": "symfony/http-kernel",
+        "version": "v5.4.0",
+        "version_normalized": "5.4.0.0",
+        "require": {
+            "php": ">=7.2.5",
+            "psr/log": "^1|^2",
+            "symfony/deprecation-contracts": "^2.1|^3",
+            "symfony/error-handler": "^4.4|^5.0|^6.0",
+            "symfony/event-dispatcher": "^5.0|^6.0",
+            "symfony/http-foundation": "^5.3.7|^6.0",
+            "symfony/polyfill-ctype": "^1.8",
+            "symfony/polyfill-php73": "^1.9",
+            "symfony/polyfill-php80": "^1.16"
+        },
+        "type": "library",
+        "install-path": "../symfony/http-kernel"
+    },
+    {
+        "name": "symfony/polyfill-ctype",
+        "version": "v1.37.0",
+        "version_normalized": "1.37.0.0",
+        "require": {
+            "php": ">=7.2"
+        },
+        "type": "library",
+        "install-path": "../symfony/polyfill-ctype"
+    },
+    {
+        "name": "symfony/polyfill-mbstring",
+        "version": "v1.38.2",
+        "version_normalized": "1.38.2.0",
+        "require": {
+            "ext-iconv": "*",
+            "php": ">=7.2"
+        },
+        "type": "library",
+        "install-path": "../symfony/polyfill-mbstring"
+    },
+    {
+        "name": "symfony/polyfill-php73",
+        "version": "v1.37.0",
+        "version_normalized": "1.37.0.0",
+        "require": {
+            "php": ">=7.2"
+        },
+        "type": "library",
+        "install-path": "../symfony/polyfill-php73"
+    },
+    {
+        "name": "symfony/polyfill-php80",
+        "version": "v1.37.0",
+        "version_normalized": "1.37.0.0",
+        "require": {
+            "php": ">=7.2"
+        },
+        "type": "library",
+        "install-path": "../symfony/polyfill-php80"
+    },
+    {
+        "name": "symfony/polyfill-php83",
+        "version": "v1.41.0",
+        "version_normalized": "1.41.0.0",
+        "require": {
+            "php": ">=7.2"
+        },
+        "type": "library",
+        "install-path": "../symfony/polyfill-php83"
+    },
+    {
+        "name": "symfony/var-dumper",
+        "version": "v6.4.43",
+        "version_normalized": "6.4.43.0",
+        "require": {
+            "php": ">=8.1",
+            "symfony/deprecation-contracts": "^2.5|^3",
+            "symfony/polyfill-mbstring": "~1.0"
+        },
+        "type": "library",
+        "install-path": "../symfony/var-dumper"
+    }
+]


### PR DESCRIPTION
PHP was scanned from `composer.json` alone — a handful of names at version ranges, with the tree they pull in invisible. On the fixture committed here, that is **3 packages seen out of 20 installed**.

PHP is the one ecosystem where both depth tiers close at once, because Composer records the same shape in both files.

## What lands

| Source | What it states | When it is read |
|---|---|---|
| `composer.lock` | what *will* be installed | first |
| `vendor/composer/installed.json` | what *is* installed | only where no lockfile covers the directory |
| `composer.json` | declared names, at ranges | last resort |

The installed tier matters more in PHP than in npm: gitignoring `composer.lock` is the documented advice for libraries, so a repository without one is common rather than exceptional. Both Composer 1 (bare array) and Composer 2 (wrapped object) envelopes are read.

Composer resolves one version of a package for the whole project, so a package name is a unique key and an edge resolves by name alone — no equivalent of npm's outward walk through nested `node_modules`. This is the shortest parser yet on the existing `walkGraph` pattern.

## Details worth a reviewer's eye

- **Platform requirements are not packages.** Every require block mixes `php`, `ext-json` and `composer-runtime-api` in with real dependencies. They describe the interpreter, match nothing in any advisory database, and only inflate the count. Every Packagist package is `vendor/name` and no platform package contains a slash, so the slash is the whole test. Applied to the pre-existing `composer.json` parser too, which dropped `php` but let `ext-*` through as if it were a package.
- **Versions are kept verbatim**, `v6.4.43` and all. OSV normalises the prefix away before matching — verified against both spellings for `symfony/http-foundation`, identical results — and the verbatim string is the one a developer greps their lockfile for.
- **Direct/transitive split** comes from the sibling `composer.json`, exactly as `yarn.lock` needs it: the lockfile itself does not record what the root project asked for. Without one, every package is still reported and only the split is lost.
- **Unresolvable edges** (virtual packages via `provide`, packages via `replace`) cost at most one route through the graph, never a package from the report.

## Verification

Scanning the fixture three ways, against live OSV:

| Source | Packages | Findings |
|---|---|---|
| `composer.json` | 3 | 14 |
| `composer.lock` | 20 | 18 |
| `vendor/composer/installed.json` | 20 | 18 |

The two full-tree sources agree exactly, as they must.

Transitive findings carry their route in the report:

```
#8 [CRITICAL] guzzlehttp/psr7 1.9.1
  CVE      : CVE-2026-49214  CVSS: 9.0
  Required : via guzzlehttp/guzzle
  Fixed in : 2.10.2
```

## Fixtures

`internal/sca/testdata/composer` was generated by Composer 2 in a container, not written by hand — which is what surfaced the `v` prefix, the platform entries and the two `installed.json` envelopes in the first place. Only fields no parser reads were stripped afterwards; `guzzlehttp/guzzle` was left whole so the tests keep exercising a real entry's worth of noise. The regeneration command is recorded at the top of `composer_test.go`.

`testdata` is already in `DefaultIgnorePaths`, so the deliberately vulnerable lockfile does not appear in the dogfooding self-scan (verified: `sca_count: 0`).

## Docs

`docs/modules.md` now marks PHP as **Full tree** and describes the three-tier fallback for both npm and PHP; `composer.lock` is removed from the not-yet-parsed list. The README's SBOM note was stale — it claimed the engine "resolves manifests rather than full lockfiles", which stopped being true at #57 — and now states the actual remaining gap, the CycloneDX `dependencies` graph.