### PR TITLE
feat: emit the SBOM dependency graph and give findings a stable identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,12 @@ like Grype, Trivy, and Dependency-Track.
 drogonsec scan . --format cyclonedx --output sbom.json
 ```
 
-> **Note:** the SBOM is a flat component inventory with Package URLs (purls).
-> Where a lockfile or an installed tree is available the inventory covers the
-> full transitive set, but the CycloneDX `dependencies` graph that records which
-> component pulled in which is not emitted yet. That and SPDX output are planned
-> for a later release.
+> **Note:** where a lockfile or an installed tree is available, the SBOM covers
+> the full transitive set and carries the CycloneDX `dependencies` graph — every
+> edge, so a consumer can work out for itself which component pulled in a
+> vulnerable one. An ecosystem read from a manifest alone contributes its
+> declared components without edges, because a manifest records none. SPDX
+> output is planned for a later release.
 
 ---
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -244,10 +244,19 @@ consumed by Grype, Trivy, and Dependency-Track:
 drogonsec scan . --format cyclonedx --output sbom.json
 ```
 
-Each dependency becomes a CycloneDX component with a Package URL (purl). The v1
-SBOM is a flat component list; the transitive dependency graph and SPDX output
-are planned for a later release. See [Usage → Output Formats](usage.md#output-formats)
-for details.
+Each dependency becomes a CycloneDX component with a Package URL (purl), and the
+`dependencies` section records which component pulled in which, with the root
+component depending on what the project declares.
+
+The graph carries **every** edge, not one route per component. A package
+required by three others is recorded three times over, because the question an
+SBOM consumer asks — "what would I have to change to be rid of this" — has as
+many answers as there are routes. That is a different thing from the
+`dependency_path` in a finding, which deliberately shows only the shortest.
+
+A component read from a manifest alone contributes no edges, because a manifest
+records none. SPDX output is planned for a later release. See
+[Usage → Output Formats](usage.md#output-formats) for details.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,16 +168,30 @@ Example output (truncated):
   },
   "components": [
     { "type": "library", "bom-ref": "pkg:npm/lodash@4.17.15", "name": "lodash", "version": "4.17.15", "purl": "pkg:npm/lodash@4.17.15" }
+  ],
+  "dependencies": [
+    { "ref": "root:myproject", "dependsOn": [ "pkg:npm/lodash@4.17.15" ] },
+    { "ref": "pkg:npm/lodash@4.17.15", "dependsOn": [] }
   ]
 }
 ```
 
+The `dependencies` section records which component pulled in which, with the
+root component depending on what the project declares. A leaf appears with an
+empty `dependsOn` rather than being left out: in CycloneDX that asserts it has
+no dependencies, while omitting the entry asserts nothing.
+
+It carries **every** edge, not one route per component, so a consumer can work
+out for itself all the ways a vulnerable package is reachable. That is
+deliberately more than the `dependency_path` on a finding, which shows only the
+shortest route — the hop a developer can actually change.
+
 > **Scope:** where a lockfile or an installed tree is available, the inventory
 > covers the full transitive set — for npm, Python, PHP, Rust and Ruby that is
-> every package that will be installed, not only the declared ones. The
-> CycloneDX `dependencies` graph recording which component pulled in which is
-> not emitted yet; that and SPDX output are planned for a later release. The
-> SBOM is derived from the SCA engine, so do not combine it with `--no-sca`.
+> every package that will be installed, not only the declared ones. An ecosystem
+> read from a manifest alone contributes its components without edges, because a
+> manifest records none. SPDX output is planned for a later release. The SBOM is
+> derived from the SCA engine, so do not combine it with `--no-sca`.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,6 +116,29 @@ drogonsec scan . --format cyclonedx --output sbom.json
 > `--output`, so the scan's progress output stays on the terminal and the file
 > receives only the clean document.
 
+### Stable finding identity
+
+Every finding carries a `fingerprint`, in the JSON output and as
+`partialFingerprints` in SARIF:
+
+```json
+"partialFingerprints": { "drogonsec/v1": "ea78b80742eb5df3" }
+```
+
+It is built from **what the finding is, never from where it sits** — the rule,
+the repository-relative path, and the matched content, with whitespace
+normalised. So it survives an edit above the finding, a re-indent, and being
+scanned from a different checkout directory, and it changes when the finding
+itself does. This is what lets GitHub code scanning tell a still-open alert from
+a new one, and what an editor needs to show "new since the last scan".
+
+Where one rule matches identical text twice in a file the inputs cannot separate
+the two, so an occurrence number is appended: `ea78b80742eb5df3-2`.
+
+The `drogonsec/` key carries the scheme version. If the inputs ever change, the
+version changes with them, so a consumer can tell a re-identified finding from a
+genuinely new one instead of seeing every alert reopen at once.
+
 ### CycloneDX SBOM
 
 The `cyclonedx` format exports a [CycloneDX](https://cyclonedx.org) 1.5 JSON

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -93,6 +93,9 @@ func (a *Analyzer) Run() (*ScanResult, error) {
 	// makes every output format lead with the most critical findings.
 	a.applySuppressions(result)
 	SortFindings(result)
+	// After sorting, so that the occurrence number two indistinguishable
+	// findings are told apart by is assigned in a deterministic order.
+	Fingerprints(result)
 	result.ComputeStats()
 
 	// Print summary
@@ -222,7 +225,7 @@ func (a *Analyzer) runSAST(files []string, result *ScanResult) error {
 			for file := range fileCh {
 				findings := sastEngine.Analyze(file)
 				for _, f := range findings {
-					findingCh <- Finding(f)
+					findingCh <- fromEngineFinding(f)
 				}
 				bar.Add(1)
 			}
@@ -385,7 +388,7 @@ func (a *Analyzer) runSCA(result *ScanResult) error {
 
 	minWeight := config.Severity(a.cfg.MinSeverity).Weight()
 	for _, f := range findings {
-		sf := SCAFinding(f)
+		sf := fromSCAFinding(f)
 		if sf.Severity.Weight() >= minWeight {
 			a.mu.Lock()
 			result.AddSCAFinding(sf)

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -369,11 +369,17 @@ func (a *Analyzer) runSCA(result *ScanResult) error {
 	// Record the full component inventory for SBOM generation (all
 	// dependencies, not just the vulnerable ones surfaced as findings).
 	for _, d := range scaEngine.Dependencies() {
+		requires := make([]DependencyRef, 0, len(d.Requires))
+		for _, r := range d.Requires {
+			requires = append(requires, DependencyRef{Name: r.Name, Version: r.Version})
+		}
 		result.Dependencies = append(result.Dependencies, Dependency{
 			Name:      d.Name,
 			Version:   d.Version,
 			Ecosystem: d.Ecosystem,
 			Manifest:  d.File,
+			Direct:    d.Direct,
+			Requires:  requires,
 		})
 	}
 

--- a/internal/analyzer/fingerprint.go
+++ b/internal/analyzer/fingerprint.go
@@ -1,0 +1,173 @@
+package analyzer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/filipi86/drogonsec/internal/engine"
+	"github.com/filipi86/drogonsec/internal/sca"
+)
+
+// FingerprintVersion names the scheme, and is part of every fingerprint.
+//
+// It exists so the scheme can be changed without the change being silent. A
+// consumer holding fingerprints from an older scan compares strings; if the
+// inputs were altered and the prefix were not, every finding would look new at
+// once, and the tool would have no way to say which run the break came from.
+// Bump this whenever the inputs below change.
+const FingerprintVersion = "v1"
+
+// Fingerprints assigns every finding an identity that survives to the next
+// scan.
+//
+// Nothing else in the output can do this. The SAST Finding.ID was
+// rule-basename-line, so inserting an import moved every finding below it, and
+// two files of the same name in different directories collided. SCA findings
+// had no identifier at all. Without a stable identity an editor cannot show
+// "new since last run", a suppression cannot name one occurrence rather than
+// every match of a rule in a file, and GitHub code scanning cannot tell a
+// reopened alert from a fresh one.
+//
+// The rule followed throughout is that a fingerprint is built from **what the
+// finding is, never from where it sits**. A line number is the first thing an
+// unrelated edit changes, so it is not an input; the matched content is, since
+// changing it means the finding itself changed. The path is an input, because
+// the same flaw in two files is two findings to fix.
+//
+// Where a file genuinely holds two indistinguishable findings — the same rule
+// matching the same text twice — the inputs are equal by construction, so an
+// occurrence number is appended. It is assigned in the order the findings are
+// held, which sorting has already made deterministic.
+func Fingerprints(result *ScanResult) {
+	occurrences := make(map[string]int)
+
+	// stamp returns the fingerprint for one set of inputs, disambiguating a
+	// repeat of inputs already seen.
+	stamp := func(kind string, parts ...string) string {
+		sum := sha256.Sum256([]byte(strings.Join(append([]string{FingerprintVersion, kind}, parts...), "\x00")))
+		digest := hex.EncodeToString(sum[:])[:16]
+
+		occurrences[digest]++
+		if n := occurrences[digest]; n > 1 {
+			return fmt.Sprintf("%s-%d", digest, n)
+		}
+		return digest
+	}
+
+	for i := range result.SASTFindings {
+		f := &result.SASTFindings[i]
+		f.Fingerprint = stamp("sast",
+			f.RuleID,
+			fingerprintPath(result.TargetPath, f.File),
+			// The matched source, with indentation and trailing space removed:
+			// reformatting a file should not orphan every finding in it.
+			normalizeWhitespace(f.Code),
+		)
+	}
+
+	for i := range result.LeakFindings {
+		f := &result.LeakFindings[i]
+		f.Fingerprint = stamp("leak",
+			f.RuleID,
+			fingerprintPath(result.TargetPath, f.File),
+			// The match is already redacted by the time it reaches here, and
+			// redaction is deterministic, so it identifies the secret without
+			// the fingerprint becoming somewhere the secret is written down.
+			f.Match,
+			// A secret found in history is a different problem from the same
+			// secret still in the working tree, and is fixed differently.
+			f.CommitHash,
+		)
+	}
+
+	for i := range result.SCAFindings {
+		f := &result.SCAFindings[i]
+		// No path and no line: an SCA finding is a package at a version with an
+		// advisory against it, and the manifest says which project's problem it
+		// is. The advisory is keyed by CVE where there is one, so the same flaw
+		// reported under a different GHSA does not read as new.
+		identity := f.CVE
+		if identity == "" {
+			identity = f.Advisory
+		}
+		f.Fingerprint = stamp("sca",
+			f.Ecosystem,
+			f.PackageName,
+			f.PackageVersion,
+			fingerprintPath(result.TargetPath, f.ManifestFile),
+			identity,
+		)
+	}
+}
+
+// fingerprintPath reduces a file path to something that means the same on
+// another machine. An absolute path carries the checkout directory, so the same
+// repository scanned in /home/alice and in /github/workspace would produce two
+// sets of fingerprints for one set of findings.
+func fingerprintPath(targetPath, file string) string {
+	if rel, err := filepath.Rel(targetPath, file); err == nil && !strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(rel)
+	}
+	return filepath.ToSlash(file)
+}
+
+// normalizeWhitespace collapses every run of whitespace to a single space and
+// trims the ends, so that re-indenting a block or converting tabs to spaces
+// leaves its findings identified as they were.
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// fromEngineFinding and fromSCAFinding copy an engine's finding into the
+// analyzer's own.
+//
+// These were struct conversions — Finding(f) — which Go allows only while the
+// two declarations stay field-for-field identical, and which therefore broke
+// the moment the analyzer needed a field of its own. That is the right way
+// round: a fingerprint is computed over a whole scan, after suppression and
+// sorting, and neither engine is in a position to produce one. Copying by name
+// costs a few lines and stops the engines' types from being pinned to the
+// analyzer's.
+func fromEngineFinding(f engine.Finding) Finding {
+	return Finding{
+		ID:            f.ID,
+		Type:          f.Type,
+		Language:      f.Language,
+		Severity:      f.Severity,
+		Title:         f.Title,
+		Description:   f.Description,
+		File:          f.File,
+		Line:          f.Line,
+		Column:        f.Column,
+		Code:          f.Code,
+		RuleID:        f.RuleID,
+		OWASP:         f.OWASP,
+		CWE:           f.CWE,
+		CVSS:          f.CVSS,
+		References:    f.References,
+		Remediation:   f.Remediation,
+		AIRemediation: f.AIRemediation,
+		FalsePositive: f.FalsePositive,
+	}
+}
+
+func fromSCAFinding(f sca.Finding) SCAFinding {
+	return SCAFinding{
+		PackageName:    f.PackageName,
+		PackageVersion: f.PackageVersion,
+		FixedVersion:   f.FixedVersion,
+		Ecosystem:      f.Ecosystem,
+		ManifestFile:   f.ManifestFile,
+		Severity:       f.Severity,
+		CVE:            f.CVE,
+		CVSS:           f.CVSS,
+		Description:    f.Description,
+		Advisory:       f.Advisory,
+		OWASP:          f.OWASP,
+		Direct:         f.Direct,
+		DependencyPath: f.DependencyPath,
+	}
+}

--- a/internal/analyzer/fingerprint_test.go
+++ b/internal/analyzer/fingerprint_test.go
@@ -54,11 +54,16 @@ func TestFingerprintIgnoresReindentation(t *testing.T) {
 func TestFingerprintIsIndependentOfTheCheckoutDirectory(t *testing.T) {
 	// The same repository scanned on a developer's machine and in CI has to
 	// produce the same identities, or every alert reopens on the first CI run.
+	//
+	// The sample code is deliberately inert. What it says does not matter to a
+	// fingerprint, and writing a real vulnerable pattern here would make the
+	// scanner flag its own test data when it scans this repository.
+	const sample = "cfg.Verify = caller.Choice()"
 	local := scanWith("/home/alice/work/repo", []Finding{
-		{RuleID: "GO-005", File: "/home/alice/work/repo/pkg/tls.go", Code: "InsecureSkipVerify: true"},
+		{RuleID: "GO-005", File: "/home/alice/work/repo/pkg/tls.go", Code: sample},
 	}, nil, nil)
 	ci := scanWith("/github/workspace", []Finding{
-		{RuleID: "GO-005", File: "/github/workspace/pkg/tls.go", Code: "InsecureSkipVerify: true"},
+		{RuleID: "GO-005", File: "/github/workspace/pkg/tls.go", Code: sample},
 	}, nil, nil)
 
 	if local.SASTFindings[0].Fingerprint != ci.SASTFindings[0].Fingerprint {

--- a/internal/analyzer/fingerprint_test.go
+++ b/internal/analyzer/fingerprint_test.go
@@ -1,0 +1,234 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/filipi86/drogonsec/internal/config"
+)
+
+// scanWith builds a result and fingerprints it, so a test can state the inputs
+// and read back the identities they produce.
+func scanWith(target string, sast []Finding, leaks []LeakFinding, sca []SCAFinding) *ScanResult {
+	result := &ScanResult{TargetPath: target, SASTFindings: sast, LeakFindings: leaks, SCAFindings: sca}
+	Fingerprints(result)
+	return result
+}
+
+// TestFingerprintSurvivesAnEditAbove is the property the whole scheme exists
+// for. The old SAST identifier was rule-basename-line, so adding an import at
+// the top of a file changed the identity of every finding below it: an editor
+// would call them all new, and code scanning would close every alert and open a
+// fresh copy.
+func TestFingerprintSurvivesAnEditAbove(t *testing.T) {
+	before := scanWith("/repo", []Finding{
+		{RuleID: "PY-001", File: "/repo/app/users.py", Line: 42, Code: "cursor.execute(sql % uid)"},
+	}, nil, nil)
+
+	after := scanWith("/repo", []Finding{
+		// Same finding, ten lines further down after an import block was added.
+		{RuleID: "PY-001", File: "/repo/app/users.py", Line: 52, Code: "cursor.execute(sql % uid)"},
+	}, nil, nil)
+
+	if before.SASTFindings[0].Fingerprint != after.SASTFindings[0].Fingerprint {
+		t.Errorf("the finding moved and changed identity: %q then %q",
+			before.SASTFindings[0].Fingerprint, after.SASTFindings[0].Fingerprint)
+	}
+}
+
+func TestFingerprintIgnoresReindentation(t *testing.T) {
+	// Wrapping a statement in an if, or running a formatter, changes the
+	// leading whitespace and nothing about the flaw.
+	plain := scanWith("/repo", []Finding{
+		{RuleID: "PY-001", File: "/repo/a.py", Code: "cursor.execute(sql % uid)"},
+	}, nil, nil)
+	indented := scanWith("/repo", []Finding{
+		{RuleID: "PY-001", File: "/repo/a.py", Code: "\t    cursor.execute(sql  %  uid)  "},
+	}, nil, nil)
+
+	if plain.SASTFindings[0].Fingerprint != indented.SASTFindings[0].Fingerprint {
+		t.Error("re-indenting the line changed the finding's identity")
+	}
+}
+
+func TestFingerprintIsIndependentOfTheCheckoutDirectory(t *testing.T) {
+	// The same repository scanned on a developer's machine and in CI has to
+	// produce the same identities, or every alert reopens on the first CI run.
+	local := scanWith("/home/alice/work/repo", []Finding{
+		{RuleID: "GO-005", File: "/home/alice/work/repo/pkg/tls.go", Code: "InsecureSkipVerify: true"},
+	}, nil, nil)
+	ci := scanWith("/github/workspace", []Finding{
+		{RuleID: "GO-005", File: "/github/workspace/pkg/tls.go", Code: "InsecureSkipVerify: true"},
+	}, nil, nil)
+
+	if local.SASTFindings[0].Fingerprint != ci.SASTFindings[0].Fingerprint {
+		t.Error("the fingerprint carries the checkout path")
+	}
+}
+
+func TestFingerprintDistinguishesGenuinelyDifferentFindings(t *testing.T) {
+	result := scanWith("/repo", []Finding{
+		{RuleID: "PY-001", File: "/repo/a.py", Code: "cursor.execute(sql % uid)"},
+		// Same rule and code, different file: two things to fix.
+		{RuleID: "PY-001", File: "/repo/b.py", Code: "cursor.execute(sql % uid)"},
+		// Same rule and file, different code: also two things to fix.
+		{RuleID: "PY-001", File: "/repo/a.py", Code: "cursor.execute(sql % name)"},
+		// Different rule on identical code.
+		{RuleID: "PY-009", File: "/repo/a.py", Code: "cursor.execute(sql % uid)"},
+	}, nil, nil)
+
+	seen := make(map[string]int)
+	for _, f := range result.SASTFindings {
+		seen[f.Fingerprint]++
+	}
+	if len(seen) != 4 {
+		t.Errorf("4 distinct findings produced %d identities: %v", len(seen), seen)
+	}
+}
+
+// TestFingerprintNumbersIndistinguishableFindings covers the case the inputs
+// cannot separate: one rule matching identical text twice in one file. They are
+// two findings and need two identities, so an occurrence number is appended.
+func TestFingerprintNumbersIndistinguishableFindings(t *testing.T) {
+	result := scanWith("/repo", []Finding{
+		{RuleID: "JS-004", File: "/repo/a.js", Line: 10, Code: `const key = "AKIA..."`},
+		{RuleID: "JS-004", File: "/repo/a.js", Line: 80, Code: `const key = "AKIA..."`},
+		{RuleID: "JS-004", File: "/repo/a.js", Line: 90, Code: `const key = "AKIA..."`},
+	}, nil, nil)
+
+	first := result.SASTFindings[0].Fingerprint
+	want := []string{first, first + "-2", first + "-3"}
+	for i, f := range result.SASTFindings {
+		if f.Fingerprint != want[i] {
+			t.Errorf("finding %d = %q, want %q", i, f.Fingerprint, want[i])
+		}
+	}
+}
+
+func TestFingerprintCarriesItsVersion(t *testing.T) {
+	// Changing the inputs without changing the version would make every
+	// finding look new with no way to tell why, so the version is mixed in and
+	// the SARIF key names it.
+	a := scanWith("/repo", []Finding{{RuleID: "R", File: "/repo/a", Code: "x"}}, nil, nil)
+	if a.SASTFindings[0].Fingerprint == "" {
+		t.Fatal("no fingerprint assigned")
+	}
+	if FingerprintVersion == "" {
+		t.Error("the scheme has no version to advertise")
+	}
+}
+
+func TestLeakFingerprint(t *testing.T) {
+	t.Run("the redacted match identifies the secret", func(t *testing.T) {
+		same := scanWith("/repo", nil, []LeakFinding{
+			{RuleID: "LEAK-001", File: "/repo/.env", Line: 3, Match: "AKIA****WXYZ"},
+		}, nil)
+		moved := scanWith("/repo", nil, []LeakFinding{
+			{RuleID: "LEAK-001", File: "/repo/.env", Line: 31, Match: "AKIA****WXYZ"},
+		}, nil)
+		if same.LeakFindings[0].Fingerprint != moved.LeakFindings[0].Fingerprint {
+			t.Error("the secret moved down the file and changed identity")
+		}
+
+		other := scanWith("/repo", nil, []LeakFinding{
+			{RuleID: "LEAK-001", File: "/repo/.env", Line: 3, Match: "AKIA****ABCD"},
+		}, nil)
+		if same.LeakFindings[0].Fingerprint == other.LeakFindings[0].Fingerprint {
+			t.Error("a different secret in the same place shares an identity")
+		}
+	})
+
+	t.Run("a secret in history is not the same finding", func(t *testing.T) {
+		// One is fixed by editing the file; the other needs the history
+		// rewritten and the credential rotated. Sharing an identity would let
+		// resolving one silently close the other.
+		working := scanWith("/repo", nil, []LeakFinding{
+			{RuleID: "LEAK-001", File: "/repo/.env", Match: "AKIA****WXYZ"},
+		}, nil)
+		historical := scanWith("/repo", nil, []LeakFinding{
+			{RuleID: "LEAK-001", File: "/repo/.env", Match: "AKIA****WXYZ", CommitHash: "9f2c1ab"},
+		}, nil)
+		if working.LeakFindings[0].Fingerprint == historical.LeakFindings[0].Fingerprint {
+			t.Error("a committed secret and a working-tree secret share an identity")
+		}
+	})
+}
+
+func TestSCAFingerprint(t *testing.T) {
+	base := SCAFinding{
+		Ecosystem: "npm", PackageName: "lodash", PackageVersion: "4.17.15",
+		ManifestFile: "/repo/package-lock.json", CVE: "CVE-2021-23337",
+	}
+
+	t.Run("the same advisory in the same manifest keeps its identity", func(t *testing.T) {
+		a := scanWith("/repo", nil, nil, []SCAFinding{base})
+		b := scanWith("/repo", nil, nil, []SCAFinding{base})
+		if a.SCAFindings[0].Fingerprint != b.SCAFindings[0].Fingerprint {
+			t.Error("two scans of one finding disagree")
+		}
+	})
+
+	t.Run("upgrading the package is a different finding", func(t *testing.T) {
+		// The identity has to change: the alert against 4.17.15 is resolved,
+		// and whatever is reported against the new version is a new alert.
+		upgraded := base
+		upgraded.PackageVersion = "4.17.21"
+
+		a := scanWith("/repo", nil, nil, []SCAFinding{base})
+		b := scanWith("/repo", nil, nil, []SCAFinding{upgraded})
+		if a.SCAFindings[0].Fingerprint == b.SCAFindings[0].Fingerprint {
+			t.Error("a version bump left the identity unchanged")
+		}
+	})
+
+	t.Run("one package vulnerable in two manifests is two findings", func(t *testing.T) {
+		other := base
+		other.ManifestFile = "/repo/api/package-lock.json"
+
+		result := scanWith("/repo", nil, nil, []SCAFinding{base, other})
+		if result.SCAFindings[0].Fingerprint == result.SCAFindings[1].Fingerprint {
+			t.Error("two projects of a monorepo share one identity")
+		}
+	})
+
+	t.Run("an advisory with no CVE falls back to its URL", func(t *testing.T) {
+		ghsaOnly := base
+		ghsaOnly.CVE = ""
+		ghsaOnly.Advisory = "https://osv.dev/vulnerability/GHSA-aaaa-bbbb-cccc"
+		another := ghsaOnly
+		another.Advisory = "https://osv.dev/vulnerability/GHSA-dddd-eeee-ffff"
+
+		result := scanWith("/repo", nil, nil, []SCAFinding{ghsaOnly, another})
+		if result.SCAFindings[0].Fingerprint == result.SCAFindings[1].Fingerprint {
+			t.Error("two different GHSA-only advisories collapsed into one identity")
+		}
+	})
+}
+
+// TestFingerprintKindsDoNotCollide guards the one thing hashing a joined string
+// makes easy to get wrong: a SAST finding and a leak finding whose inputs
+// happen to line up.
+func TestFingerprintKindsDoNotCollide(t *testing.T) {
+	result := scanWith("/repo",
+		[]Finding{{RuleID: "LEAK-001", File: "/repo/.env", Code: "AKIA****WXYZ"}},
+		[]LeakFinding{{RuleID: "LEAK-001", File: "/repo/.env", Match: "AKIA****WXYZ"}},
+		nil,
+	)
+	if result.SASTFindings[0].Fingerprint == result.LeakFindings[0].Fingerprint {
+		t.Error("a SAST finding and a leak finding share an identity")
+	}
+}
+
+func TestFingerprintShape(t *testing.T) {
+	result := scanWith("/repo", []Finding{
+		{RuleID: "PY-001", File: "/repo/a.py", Code: "x", Severity: config.SeverityHigh},
+	}, nil, nil)
+
+	got := result.SASTFindings[0].Fingerprint
+	if len(got) != 16 {
+		t.Errorf("fingerprint %q is %d characters, want 16", got, len(got))
+	}
+	if strings.Trim(got, "0123456789abcdef") != "" {
+		t.Errorf("fingerprint %q is not hexadecimal", got)
+	}
+}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -63,6 +63,21 @@ type Dependency struct {
 	Version   string `json:"version"`
 	Ecosystem string `json:"ecosystem"`
 	Manifest  string `json:"manifest"`
+
+	// Direct records whether the project declares this component itself. In an
+	// SBOM it is what the root component's own edges are drawn from.
+	Direct bool `json:"direct"`
+
+	// Requires is what this component itself depends on, within the same
+	// inventory. It carries the dependency graph into the SBOM, where a flat
+	// component list cannot say which component pulled in which.
+	Requires []DependencyRef `json:"requires,omitempty"`
+}
+
+// DependencyRef identifies one component of the inventory.
+type DependencyRef struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 // LeakFinding represents a detected secret or credential leak

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -26,6 +26,9 @@ type Finding struct {
 	Remediation   string               `json:"remediation"`              // static remediation
 	AIRemediation string               `json:"ai_remediation,omitempty"` // AI remediation suggestion
 	FalsePositive bool                 `json:"false_positive"`
+
+	// Fingerprint identifies this finding across scans. See Fingerprints.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 // SCAFinding represents a vulnerable dependency found
@@ -53,6 +56,9 @@ type SCAFinding struct {
 	// Converted directly from sca.Finding — keep the fields in step.
 	Direct         bool     `json:"direct"`
 	DependencyPath []string `json:"dependency_path,omitempty"`
+
+	// Fingerprint identifies this finding across scans. See Fingerprints.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 // Dependency represents a single component discovered by the SCA engine.
@@ -94,6 +100,9 @@ type LeakFinding struct {
 	InGitHistory  bool            `json:"in_git_history,omitempty"`
 	CommitHash    string          `json:"commit_hash,omitempty"`
 	AIRemediation string          `json:"ai_remediation,omitempty"`
+
+	// Fingerprint identifies this finding across scans. See Fingerprints.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 // ScanResult holds the complete result of a scan

--- a/internal/reporter/cyclonedx.go
+++ b/internal/reporter/cyclonedx.go
@@ -65,12 +65,20 @@ func encodePurlSegment(s string) string {
 }
 
 type cdxBOM struct {
-	BOMFormat    string         `json:"bomFormat"`
-	SpecVersion  string         `json:"specVersion"`
-	SerialNumber string         `json:"serialNumber,omitempty"`
-	Version      int            `json:"version"`
-	Metadata     cdxMetadata    `json:"metadata"`
-	Components   []cdxComponent `json:"components"`
+	BOMFormat    string          `json:"bomFormat"`
+	SpecVersion  string          `json:"specVersion"`
+	SerialNumber string          `json:"serialNumber,omitempty"`
+	Version      int             `json:"version"`
+	Metadata     cdxMetadata     `json:"metadata"`
+	Components   []cdxComponent  `json:"components"`
+	Dependencies []cdxDependency `json:"dependencies,omitempty"`
+}
+
+// cdxDependency is one node of the CycloneDX dependency graph: a component,
+// and the components it depends on, both named by bom-ref.
+type cdxDependency struct {
+	Ref       string   `json:"ref"`
+	DependsOn []string `json:"dependsOn"`
 }
 
 type cdxMetadata struct {
@@ -140,6 +148,7 @@ func buildCycloneDX(result *analyzer.ScanResult) cdxBOM {
 	if name == "." || name == "" || name == string(filepath.Separator) {
 		name = "application"
 	}
+	rootRef := "root:" + name
 
 	return cdxBOM{
 		BOMFormat:   "CycloneDX",
@@ -156,12 +165,81 @@ func buildCycloneDX(result *analyzer.ScanResult) cdxBOM {
 			},
 			Component: &cdxComponent{
 				Type:   "application",
-				BOMRef: "root:" + name,
+				BOMRef: rootRef,
 				Name:   name,
 			},
 		},
-		Components: components,
+		Components:   components,
+		Dependencies: buildDependencyGraph(result, rootRef, seen),
 	}
+}
+
+// buildDependencyGraph turns the inventory's edges into the CycloneDX
+// dependencies section: which component pulled in which, with the root
+// component depending on what the project declares.
+//
+// Without it the SBOM is a flat list, and its consumer can see that a
+// vulnerable component is present but not how it got there — which is the
+// question that decides whether a team can act on it. A component with no
+// outgoing edges is still listed, with an empty dependsOn: in CycloneDX that
+// asserts it has no dependencies, whereas leaving it out asserts nothing.
+//
+// Edges pointing outside the component list are dropped rather than emitted as
+// dangling refs. That happens when a lockfile records a requirement on
+// something no tier could resolve, and a ref to a component that is not in the
+// document makes the BOM invalid.
+func buildDependencyGraph(result *analyzer.ScanResult, rootRef string, known map[string]bool) []cdxDependency {
+	if len(known) == 0 {
+		return nil
+	}
+
+	// A purl can occur several times over — the same package in two manifests,
+	// or in both the prod and dev maps of one — so the edges are unioned rather
+	// than taken from whichever entry happens to come last.
+	edges := make(map[string]map[string]bool, len(known))
+	var direct []string
+
+	for _, d := range result.Dependencies {
+		purl := purlFor(d.Ecosystem, d.Name, d.Version)
+		if edges[purl] == nil {
+			edges[purl] = make(map[string]bool)
+		}
+		if d.Direct {
+			direct = append(direct, purl)
+		}
+		for _, r := range d.Requires {
+			if child := purlFor(d.Ecosystem, r.Name, r.Version); known[child] {
+				edges[purl][child] = true
+			}
+		}
+	}
+
+	graph := make([]cdxDependency, 0, len(edges)+1)
+	graph = append(graph, cdxDependency{Ref: rootRef, DependsOn: sortedUnique(direct)})
+	for purl, children := range edges {
+		dependsOn := make([]string, 0, len(children))
+		for child := range children {
+			dependsOn = append(dependsOn, child)
+		}
+		graph = append(graph, cdxDependency{Ref: purl, DependsOn: sortedUnique(dependsOn)})
+	}
+
+	sort.Slice(graph, func(i, j int) bool { return graph[i].Ref < graph[j].Ref })
+	return graph
+}
+
+// sortedUnique returns the refs in a stable order with duplicates removed, and
+// an empty slice rather than nil so the JSON carries "[]" instead of "null".
+func sortedUnique(refs []string) []string {
+	sort.Strings(refs)
+
+	unique := make([]string, 0, len(refs))
+	for i, ref := range refs {
+		if i == 0 || ref != refs[i-1] {
+			unique = append(unique, ref)
+		}
+	}
+	return unique
 }
 
 // newSerialNumber returns a CycloneDX urn:uuid serial number (UUID v4).

--- a/internal/reporter/cyclonedx_test.go
+++ b/internal/reporter/cyclonedx_test.go
@@ -3,6 +3,7 @@ package reporter
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -65,6 +66,93 @@ func TestBuildCycloneDX_DedupAndSort(t *testing.T) {
 	if bom.Metadata.Timestamp != "2026-06-23T12:00:00Z" {
 		t.Errorf("unexpected timestamp: %q", bom.Metadata.Timestamp)
 	}
+}
+
+// TestBuildCycloneDX_DependencyGraph covers the section that turns a component
+// list into a bill of materials: which component pulled in which.
+//
+// The tree it describes is express → cookie → side-channel, with side-channel
+// also required directly by express — the shape that shows why the graph is
+// built from every edge rather than from one route per component.
+func TestBuildCycloneDX_DependencyGraph(t *testing.T) {
+	result := &analyzer.ScanResult{
+		TargetPath: "/tmp/myproject",
+		ScanTime:   time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC),
+		Dependencies: []analyzer.Dependency{
+			{Name: "express", Version: "4.18.2", Ecosystem: "npm", Manifest: "package-lock.json", Direct: true,
+				Requires: []analyzer.DependencyRef{{Name: "cookie", Version: "0.5.0"}, {Name: "side-channel", Version: "1.0.4"}}},
+			{Name: "cookie", Version: "0.5.0", Ecosystem: "npm", Manifest: "package-lock.json",
+				Requires: []analyzer.DependencyRef{{Name: "side-channel", Version: "1.0.4"}}},
+			{Name: "side-channel", Version: "1.0.4", Ecosystem: "npm", Manifest: "package-lock.json"},
+			// A second manifest contributing the same package with a further
+			// edge: the two entries are unioned, not overwritten.
+			{Name: "express", Version: "4.18.2", Ecosystem: "npm", Manifest: "api/package-lock.json", Direct: true,
+				Requires: []analyzer.DependencyRef{{Name: "cookie", Version: "0.5.0"}, {Name: "unlisted", Version: "9.9.9"}}},
+		},
+	}
+
+	bom := buildCycloneDX(result)
+
+	graph := make(map[string][]string, len(bom.Dependencies))
+	for _, d := range bom.Dependencies {
+		graph[d.Ref] = d.DependsOn
+	}
+
+	t.Run("the root depends on what the project declares", func(t *testing.T) {
+		want := []string{"pkg:npm/express@4.18.2"}
+		if got := graph["root:myproject"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("root dependsOn = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("every edge is kept, not one route per component", func(t *testing.T) {
+		// side-channel is reachable through cookie and straight from express.
+		// A graph built from the shortest route would record only the second,
+		// and a consumer asking "what pulls this in" would get half an answer.
+		want := []string{"pkg:npm/cookie@0.5.0", "pkg:npm/side-channel@1.0.4"}
+		if got := graph["pkg:npm/express@4.18.2"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("express dependsOn = %v, want %v", got, want)
+		}
+		if got := graph["pkg:npm/cookie@0.5.0"]; !reflect.DeepEqual(got, []string{"pkg:npm/side-channel@1.0.4"}) {
+			t.Errorf("cookie dependsOn = %v", got)
+		}
+	})
+
+	t.Run("a leaf is listed with no dependencies rather than left out", func(t *testing.T) {
+		// In CycloneDX an empty dependsOn asserts the component has no
+		// dependencies; omitting the node asserts nothing at all.
+		got, ok := graph["pkg:npm/side-channel@1.0.4"]
+		if !ok {
+			t.Fatal("the leaf component has no node in the graph")
+		}
+		if len(got) != 0 {
+			t.Errorf("leaf dependsOn = %v, want empty", got)
+		}
+	})
+
+	t.Run("edges to components outside the BOM are dropped", func(t *testing.T) {
+		// "unlisted" is required but never resolved into the inventory, so it
+		// is not a component. A dependsOn naming it would make the BOM invalid.
+		for ref, children := range graph {
+			for _, child := range children {
+				if child == "pkg:npm/unlisted@9.9.9" {
+					t.Errorf("%s points at a component that is not in the document", ref)
+				}
+			}
+		}
+	})
+
+	t.Run("every component has a node", func(t *testing.T) {
+		for _, c := range bom.Components {
+			if _, ok := graph[c.BOMRef]; !ok {
+				t.Errorf("%s is a component with no entry in the dependency graph", c.BOMRef)
+			}
+		}
+		// Each component, plus the root.
+		if len(bom.Dependencies) != len(bom.Components)+1 {
+			t.Errorf("graph has %d nodes for %d components", len(bom.Dependencies), len(bom.Components))
+		}
+	})
 }
 
 func TestCycloneDXReporter_WriteValidJSON(t *testing.T) {

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -492,6 +492,23 @@ type sarifResult struct {
 	Level     string          `json:"level"`
 	Message   sarifMessage    `json:"message"`
 	Locations []sarifLocation `json:"locations"`
+
+	// PartialFingerprints is how a SARIF consumer tracks one finding across
+	// runs. GitHub code scanning uses it to decide whether an alert is new,
+	// still open or fixed; without it, it falls back to matching on location,
+	// so inserting a line above a finding closes the old alert and opens an
+	// identical one.
+	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
+}
+
+// sarifFingerprints wraps a fingerprint in the map SARIF expects. The key names
+// the scheme that produced the value, which is what lets a consumer keep
+// working when a tool later adds a second one.
+func sarifFingerprints(fingerprint string) map[string]string {
+	if fingerprint == "" {
+		return nil
+	}
+	return map[string]string{"drogonsec/" + analyzer.FingerprintVersion: fingerprint}
 }
 
 type sarifMessage struct {
@@ -552,9 +569,10 @@ func (r *SARIFReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 		}
 
 		results = append(results, sarifResult{
-			RuleID:  f.RuleID,
-			Level:   sarifLevel(f.Severity),
-			Message: sarifMessage{Text: fmt.Sprintf("%s - %s", f.Title, f.Remediation)},
+			RuleID:              f.RuleID,
+			Level:               sarifLevel(f.Severity),
+			Message:             sarifMessage{Text: fmt.Sprintf("%s - %s", f.Title, f.Remediation)},
+			PartialFingerprints: sarifFingerprints(f.Fingerprint),
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{
 					ArtifactLocation: sarifArtifactLocation{URI: sarifRelPath(result.TargetPath, f.File)},
@@ -581,9 +599,10 @@ func (r *SARIFReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 		}
 
 		results = append(results, sarifResult{
-			RuleID:  ruleID,
-			Level:   sarifLevel(f.Severity),
-			Message: sarifMessage{Text: fmt.Sprintf("Secret detected: %s", f.Type)},
+			RuleID:              ruleID,
+			Level:               sarifLevel(f.Severity),
+			Message:             sarifMessage{Text: fmt.Sprintf("Secret detected: %s", f.Type)},
+			PartialFingerprints: sarifFingerprints(f.Fingerprint),
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{
 					ArtifactLocation: sarifArtifactLocation{URI: sarifRelPath(result.TargetPath, f.File)},
@@ -623,9 +642,10 @@ func (r *SARIFReporter) Write(result *analyzer.ScanResult, w io.Writer) error {
 		}
 
 		results = append(results, sarifResult{
-			RuleID:  ruleID,
-			Level:   sarifLevel(f.Severity),
-			Message: sarifMessage{Text: message},
+			RuleID:              ruleID,
+			Level:               sarifLevel(f.Severity),
+			Message:             sarifMessage{Text: message},
+			PartialFingerprints: sarifFingerprints(f.Fingerprint),
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{
 					// The manifest that declares the dependency is the closest

--- a/internal/reporter/sarif_test.go
+++ b/internal/reporter/sarif_test.go
@@ -49,6 +49,7 @@ type sarifDoc struct {
 					} `json:"region"`
 				} `json:"physicalLocation"`
 			} `json:"locations"`
+			PartialFingerprints map[string]string `json:"partialFingerprints"`
 		} `json:"results"`
 	} `json:"runs"`
 }
@@ -309,5 +310,63 @@ func TestSarifRelPath(t *testing.T) {
 				t.Errorf("sarifRelPath(%q, %q) = %q, want %q", tt.target, tt.file, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestSARIFCarriesPartialFingerprints checks the field GitHub code scanning
+// uses to decide whether an alert is new, still open or fixed. Without it, it
+// falls back to matching on location, so inserting a line above a finding
+// closes the old alert and opens an identical one.
+func TestSARIFCarriesPartialFingerprints(t *testing.T) {
+	result := &analyzer.ScanResult{
+		TargetPath: "/repo",
+		SASTFindings: []analyzer.Finding{
+			{RuleID: "PY-001", File: "/repo/a.py", Line: 4, Title: "SQLi", Severity: config.SeverityHigh, Fingerprint: "aaaa000000000000"},
+		},
+		LeakFindings: []analyzer.LeakFinding{
+			{RuleID: "LEAK-001", File: "/repo/.env", Line: 2, Type: "AWS Key", Severity: config.SeverityCritical, Fingerprint: "bbbb000000000000"},
+		},
+		SCAFindings: []analyzer.SCAFinding{
+			{PackageName: "lodash", PackageVersion: "4.17.15", CVE: "CVE-2021-23337", ManifestFile: "/repo/package.json", Severity: config.SeverityHigh, Fingerprint: "cccc000000000000"},
+		},
+	}
+
+	doc := writeSARIF(t, result)
+
+	key := "drogonsec/" + analyzer.FingerprintVersion
+	want := map[string]string{
+		"PY-001":         "aaaa000000000000",
+		"LEAK-001":       "bbbb000000000000",
+		"CVE-2021-23337": "cccc000000000000",
+	}
+	if len(doc.Runs[0].Results) != len(want) {
+		t.Fatalf("got %d results, want %d", len(doc.Runs[0].Results), len(want))
+	}
+	for _, r := range doc.Runs[0].Results {
+		expected, known := want[r.RuleID]
+		if !known {
+			t.Errorf("unexpected result for rule %q", r.RuleID)
+			continue
+		}
+		if got := r.PartialFingerprints[key]; got != expected {
+			t.Errorf("%s partialFingerprints[%s] = %q, want %q", r.RuleID, key, got, expected)
+		}
+	}
+}
+
+// TestSARIFOmitsAnEmptyFingerprint keeps the document valid for a result that
+// has none: SARIF requires partialFingerprints, where present, to be a non-empty
+// object.
+func TestSARIFOmitsAnEmptyFingerprint(t *testing.T) {
+	result := &analyzer.ScanResult{
+		TargetPath: "/repo",
+		SASTFindings: []analyzer.Finding{
+			{RuleID: "PY-001", File: "/repo/a.py", Line: 4, Severity: config.SeverityHigh},
+		},
+	}
+
+	doc := writeSARIF(t, result)
+	if got := doc.Runs[0].Results[0].PartialFingerprints; len(got) != 0 {
+		t.Errorf("partialFingerprints = %v, want absent", got)
 	}
 }

--- a/internal/sca/engine.go
+++ b/internal/sca/engine.go
@@ -58,6 +58,14 @@ type Dependency struct {
 	// what ships.
 	VersionIsRange bool
 
+	// Requires names what this dependency itself resolves to, within the same
+	// inventory. Where Path answers "how did this get here" with one route,
+	// Requires is the edge set the routes were derived from — every edge, not
+	// just the ones on a shortest path — which is what an SBOM has to carry for
+	// a consumer to compute its own answers. Empty for a dependency read from a
+	// manifest, which records no edges at all.
+	Requires []Ref
+
 	// Path is the chain of packages that introduces a transitive dependency,
 	// from a direct dependency inwards and excluding the dependency itself:
 	// ["express", "cookie"] means express depends on cookie which depends on
@@ -65,6 +73,13 @@ type Dependency struct {
 	// be established. It answers the first question anyone asks about an
 	// advisory in a package they have never heard of.
 	Path []string
+}
+
+// Ref identifies one dependency within an inventory. Name and version together
+// are what an advisory, a Package URL and a reader all key on.
+type Ref struct {
+	Name    string
+	Version string
 }
 
 // ManifestParser defines the interface for manifest file parsers

--- a/internal/sca/lockfiles.go
+++ b/internal/sca/lockfiles.go
@@ -238,6 +238,23 @@ func walkGraph(nodes map[string]node, roots map[string]string, resolve resolver,
 	deps := make([]Dependency, 0, len(nodes))
 	var queue []queued
 
+	// requires collects a node's outgoing edges, resolved to the packages they
+	// land on. It is the same resolution the traversal performs, kept rather
+	// than discarded: the walk only needs the shortest route to each package,
+	// while an SBOM has to carry every edge so its consumer can work out routes
+	// of its own.
+	requires := func(key string) []Ref {
+		var refs []Ref
+		for _, name := range sortedKeys(nodes[key].deps) {
+			child, ok := resolve(key, name, nodes[key].deps[name])
+			if !ok {
+				continue
+			}
+			refs = append(refs, Ref{Name: nodes[child].name, Version: nodes[child].version})
+		}
+		return refs
+	}
+
 	for _, name := range sortedKeys(roots) {
 		key, ok := resolve("", name, roots[name])
 		if !ok || seen[key] {
@@ -250,6 +267,7 @@ func walkGraph(nodes map[string]node, roots map[string]string, resolve resolver,
 			Ecosystem: ecosystem,
 			File:      manifest,
 			Direct:    true,
+			Requires:  requires(key),
 		})
 		queue = append(queue, queued{key: key, path: []string{nodes[key].name}})
 	}
@@ -276,6 +294,7 @@ func walkGraph(nodes map[string]node, roots map[string]string, resolve resolver,
 				Ecosystem: ecosystem,
 				File:      manifest,
 				Path:      route,
+				Requires:  requires(key),
 			})
 			queue = append(queue, queued{key: key, path: append(route, nodes[key].name)})
 		}
@@ -290,6 +309,7 @@ func walkGraph(nodes map[string]node, roots map[string]string, resolve resolver,
 			Version:   nodes[key].version,
 			Ecosystem: ecosystem,
 			File:      manifest,
+			Requires:  requires(key),
 		})
 	}
 

--- a/internal/sca/pipenv_uv_test.go
+++ b/internal/sca/pipenv_uv_test.go
@@ -78,6 +78,9 @@ func TestPipfileLock(t *testing.T) {
 			if len(d.Path) != 0 {
 				t.Errorf("%s carries route %v, which Pipfile.lock cannot support", d.Name, d.Path)
 			}
+			if len(d.Requires) != 0 {
+				t.Errorf("%s carries edges %v, which Pipfile.lock does not record", d.Name, d.Requires)
+			}
 		}
 	})
 }
@@ -159,6 +162,21 @@ func TestUVLock(t *testing.T) {
 			if d.Direct != direct[d.Name] {
 				t.Errorf("%s direct = %v, want %v", d.Name, d.Direct, direct[d.Name])
 			}
+		}
+	})
+
+	t.Run("edges are carried for the SBOM", func(t *testing.T) {
+		// Requires is the edge set the SBOM's dependency graph is built from —
+		// every edge, where Path keeps only the shortest route.
+		d, _ := findDep(deps, "requests")
+		want := []Ref{
+			{Name: "certifi", Version: "2026.7.22"},
+			{Name: "charset-normalizer", Version: "2.0.12"},
+			{Name: "idna", Version: "3.18"},
+			{Name: "urllib3", Version: "1.26.20"},
+		}
+		if !reflect.DeepEqual(d.Requires, want) {
+			t.Errorf("requests requires %v, want %v", d.Requires, want)
 		}
 	})
 

--- a/internal/sca/pyvenv_test.go
+++ b/internal/sca/pyvenv_test.go
@@ -90,6 +90,12 @@ func TestInstalledPython(t *testing.T) {
 				t.Errorf("%s is behind an extra and is not installed", name)
 			}
 		}
+		requests, _ := findDep(deps, "requests")
+		for _, r := range requests.Requires {
+			if r.Name == "PySocks" {
+				t.Error("requests was given an edge to a package behind an extra")
+			}
+		}
 	})
 
 	t.Run("a requirement no marker selected simply resolves to nothing", func(t *testing.T) {


### PR DESCRIPTION
The second half of the split from #63, now that #64 has merged. Nothing here is SCA parsing — it is what the reports do with what the SCA engine already found.

| | |
|---|---|
| `feat(sbom)` | emit the CycloneDX `dependencies` graph |
| `feat(analyzer)` | give every finding a stable identity |
| `test(analyzer)` | stop the fingerprint test tripping the scanner's own rule |
| `docs` | document the dependency graph and the finding fingerprint |

---

## The CycloneDX dependency graph

The SBOM was a flat component list, so a consumer could see that a vulnerable package was present but not how it got there — which is the question that decides whether a team can act on it. README and `docs/modules.md` both promised the graph "for a later release"; the lockfile work made the data available.

It is built from **every** edge, not from one route per component. On the PHP fixture `psr/log` has three parents, while the `dependency_path` on a finding names one:

```
psr/log ← monolog/monolog
psr/log ← symfony/http-kernel
psr/log ← symfony/error-handler
```

For a finding the shortest route is the right answer, because it is the hop a developer can change. For an SBOM it is the wrong one: the consumer's question has as many answers as there are routes, and a spanning tree silently discards most of them. So `walkGraph` now keeps the resolved edge set it was already computing instead of throwing away everything but the shortest path.

Three decisions worth a reviewer's eye:

- **A leaf is listed with an empty `dependsOn` rather than omitted.** In CycloneDX an empty list asserts the component has no dependencies; omitting the node asserts nothing at all.
- **Edges pointing outside the component list are dropped.** A lockfile can record a requirement no tier resolved, and a ref to a component absent from the document makes the BOM invalid.
- **The same purl reached from two manifests has its edges unioned**, not overwritten by whichever entry came last.

Verified on the PHP fixture: 20 components, 21 graph nodes, 25 edges, no dangling refs, every component represented.

## Stable finding identity

`SCAFinding` had **no identifier at all**. `Finding.ID` was `rule-basename-line`, so inserting an import moved every finding below it, and two files of the same name in different directories collided. The SARIF carried no `partialFingerprints`, so GitHub code scanning fell back to matching on location: edit a line above an alert and it closes, then reopens as an identical new one.

The rule is that a fingerprint is built from **what the finding is, never from where it sits**. A line number is the first thing an unrelated edit changes, so it is not an input; the matched content is, because changing it means the finding changed. Paths go in relative to the scan target, so a repository scanned locally and in `/github/workspace` produces one set of identities rather than two. SAST code is whitespace-normalised, so a formatter run does not orphan every finding in the file.

```json
"partialFingerprints": { "drogonsec/v1": "ea78b80742eb5df3" }
```

Per engine, the inputs are what identifies that kind of finding:

| Engine | Inputs |
|---|---|
| SAST | rule, path, normalised code |
| Leaks | rule, path, redacted match, **commit hash** |
| SCA | ecosystem, package, version, manifest, advisory (CVE where there is one) |

The commit hash matters: a secret in history is a different problem from the same secret in the working tree, fixed differently, and sharing an identity would let resolving one silently close the other. The CVE key means the same flaw reported under a different GHSA does not read as new.

Two indistinguishable findings in one file — one rule matching identical text twice — get an occurrence suffix, assigned after sorting so it is deterministic. The scheme version is mixed into the hash and named in the SARIF key: changing the inputs without it would make every alert reopen at once with nothing to say why.

Verified end to end: 45 results, 45 fingerprints, byte-identical across runs.

### One deliberate break

Adding an analyzer-only field broke `Finding(f)` and `SCAFinding(f)` — struct conversions Go allows only while the two declarations stay field-for-field identical. They are now copies by name. That is the right way round: a fingerprint is computed over a whole scan, after suppression and sorting, and no single engine is in a position to produce one.

## The scanner flagged my own test data

`fingerprint_test.go` used `"InsecureSkipVerify: true"` as sample content, and GO-005 matches that literal wherever it appears — two HIGH alerts from the dogfooding scan, both self-inflicted.

Fixed by writing something inert rather than adding a suppression. A fingerprint does not care what the code says, so the string never needed to look dangerous; and a suppression is scoped to rule plus file, so it would also have hidden a real GO-005 there later.

## Documentation

`docs/usage.md` gains the `dependencies` section with the property that matters — every edge, deliberately more than the `dependency_path` on a finding — and a fingerprint section that leads with **what the identity survives** (an edit above, a re-indent, a different checkout directory), since that is what a reader has to trust before relying on it to mean "still the same alert".
