### PR TITLE
fix(deps): bump golang.org/x/crypto to v0.56.0 to get main green again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`golang.org/x/crypto` moves to v0.56.0.** Two advisories in
+  `golang.org/x/crypto/ssh` — `GO-2026-6354` and `GO-2026-6355`, both denial of
+  service on a deadlocked channel — are reachable from `monitor.shallowClone`,
+  which calls `git.PlainClone` and through it `ssh.NewClientConn`. Both are
+  fixed in v0.56.0. As with the Go 1.26.6 bump below, `govulncheck` had started
+  failing the build on `main` as the advisories were published, without any
+  change to the source. The dependency is indirect, via go-git, so only the
+  version pin moves; `golang.org/x/text` follows to v0.41.0 as a transitive
+  requirement.
+
 - **The build moves to Go 1.26.6**, in CI, in the Docker image and as the floor
   in `go.mod`. Five advisories in the standard library — `net/http`,
   `crypto/tls`, `net/url` and `encoding/asn1` — are reachable from the monitor's

--- a/go.mod
+++ b/go.mod
@@ -43,10 +43,10 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -136,8 +136,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
 golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
-golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

`Build & Test` is red on `main` (runs [33699240365](https://github.com/filipi86/drogonsec/actions/runs/33699240365), [33699248225](https://github.com/filipi86/drogonsec/actions/runs/33699248225), [33699253754](https://github.com/filipi86/drogonsec/actions/runs/33699253754)). The `govulncheck ./...` step exits 3 on two advisories in `golang.org/x/crypto/ssh` that were published after the last green run:

```
Vulnerability #1: GO-2026-6355
    Prevent DoS on deadlocked established channel in golang.org/x/crypto/ssh
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.54.0
    Fixed in: golang.org/x/crypto@v0.56.0
      #1: internal/monitor/clone.go:18:28: monitor.shallowClone calls git.PlainClone,
          which eventually calls ssh.NewClientConn

Vulnerability #2: GO-2026-6354
    Prevent DoS on deadlocked undecided channel in golang.org/x/crypto/ssh
    (same module, same version, same trace)
```

Both are reachable from our code, so `govulncheck` fails the job by design. Nothing in the source changed — the three dependency merges that landed just before simply happened to be the next pushes to run against a vulnerability database that had moved.

This bumps the pin to the fixed version:

- `golang.org/x/crypto` v0.54.0 → v0.56.0 (indirect, via go-git)
- `golang.org/x/text` v0.40.0 → v0.41.0 (transitive requirement of the above)

No Go source is touched; the diff is `go.mod`, `go.sum` and a `CHANGELOG.md` entry. It mirrors the existing Go 1.26.6 entry under `### Security`, which records the same situation from a previous round of advisories.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New detection rule or secret pattern
- [ ] Documentation
- [x] Build, CI, or dependency change

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide and signed the CLA
- [x] `go build ./...` and `go test ./...` pass locally
- [ ] `gofmt` and `golangci-lint run` are clean — `gofmt -l` is clean; `golangci-lint` could not be run locally (see Notes)
- [ ] I added or updated tests where appropriate — not applicable, no source change
- [x] I updated documentation and `CHANGELOG.md` (Unreleased section) where relevant
- [ ] My changes do not introduce new `govulncheck` findings — could not be verified locally (see Notes)

## Notes for Reviewers

Two checklist items could not be verified locally, and CI is the authority on both:

- **`govulncheck`** needs `vuln.go.dev`, which the network policy of the environment this was prepared in blocks (403 at the gateway). The evidence that v0.56.0 is the right target is the CI log itself, which names `Fixed in: golang.org/x/crypto@v0.56.0` for both advisories. If a third advisory has been published since, this PR's own run will say so.
- **`golangci-lint`** could not run locally either: the available binary is v2.5.0, built with go1.25, and it refuses a module targeting `go 1.26.6`. CI pins v2.12.2, which handles it. Since no `.go` file is touched, the lint result should be identical to `main`'s.

What was verified locally, replicating the `ci.yml` steps:

| Step | Result |
| --- | --- |
| `go mod verify` | all modules verified |
| `go vet ./...` | clean |
| `go test ./... -race -coverprofile=coverage.out -covermode=atomic` | 12 packages ok |
| `make build EXTRA_LDFLAGS=...` | builds |
| `gofmt -l .` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZTmNGQnYCa7si4N5uRB6E

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZTmNGQnYCa7si4N5uRB6E)_